### PR TITLE
bugfix: adapted removeColNa to the new treatment of missing data in a…

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,8 +2,8 @@ Encoding: UTF-8
 Package: quitte
 Type: Package
 Title: Bits and pieces of code to use with quitte-style data frames
-Version: 0.3078.2
-Date: 2020-04-08
+Version: 0.3078.3
+Date: 2020-04-22
 Authors@R: c(person("Michaja", "Pehl", role = c("aut", "cre"),
 		            email = "pehl@pik-potsdam.de"),
 		     person("Nico", "Bauer", role = "aut",
@@ -48,5 +48,5 @@ Suggests: gdxrrw,
     testthat
 Repository: CRAN
 RoxygenNote: 7.1.0
-ValidationKey: 565157520
+ValidationKey: 565606842
 VignetteBuilder: knitr

--- a/R/removeColNa.R
+++ b/R/removeColNa.R
@@ -1,6 +1,6 @@
 #' Removes all NA columns of a data frame
 #'
-#' \code{removeColNa()} Removes all columns of a data frame for which all entries are NA 
+#' \code{removeColNa()} Removes all columns of a data frame for which all entries are NA, or the default of fct_explict_na 
 #'
 #' @param df a data frame
 #' @return a data frame
@@ -11,13 +11,21 @@
 #'     factor = as.factor(LETTERS[1:5]),
 #'     value = 1:5,
 #'     unit = NA,
+#'     unit2 = forcats::fct_explicit_na(factor(NA)),
 #'     stringsAsFactors = FALSE)
 #' str(df)
 #' str(removeColNa(df))
+#' @importFrom forcats fct_explicit_na
+#' 
 #' @export
 #' 
 
 removeColNa <- function(df){
+  
+  .fct_default = levels(forcats::fct_explicit_na(factor(NA)))
+  
+  df = df[colSums(!is.na(df)) > 0]
+  df = df[colSums(df != .fct_default) > 0]
 
-return(df[colSums(!is.na(df)) > 0])
+return(df)
 }

--- a/tests/testthat/test-removeColNa.R
+++ b/tests/testthat/test-removeColNa.R
@@ -1,0 +1,24 @@
+context("removeColNa()")
+
+# create some test data
+df <- data.frame(
+    character = letters[1:5],
+    factor = as.factor(LETTERS[1:5]),
+    value = 1:5,
+    unit = NA,
+    unit2 = forcats::fct_explicit_na(factor(NA)),
+    stringsAsFactors = FALSE)
+
+df_removed <- removeColNa(df)
+
+test_that(
+    'Test if all NA columns disappeared',
+    {
+        # identical number of columns
+        expect_equal(
+            object   = setdiff(colnames(df), colnames(df_removed)),
+            expected = c("unit","unit2"))
+        
+       
+    }
+)


### PR DESCRIPTION
…s.quitte

After 09609bd54b14bb39aee827bacf763130be702efe , removeColNa did not remove empty columns from as.quitte anymore. This led to failures in the REMIND input preparation.

