### PR TITLE
Refactor due to function deprecation

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "quitte: Bits and pieces of code to use with quitte-style data frames",
-  "version": "0.3080.0",
+  "version": "0.3081.0",
   "description": "<p>A collection of functions for easily dealing with\n    quitte-style data frames, doing multi-model comparisons and plots.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Encoding: UTF-8
 Package: quitte
 Type: Package
 Title: Bits and pieces of code to use with quitte-style data frames
-Version: 0.3080.0
+Version: 0.3081.0
 Date: 2020-07-08
 Authors@R: c(person("Michaja", "Pehl", role = c("aut", "cre"),
 		            email = "pehl@pik-potsdam.de"),
@@ -48,5 +48,5 @@ Suggests: gdxrrw,
     testthat
 Repository: CRAN
 RoxygenNote: 7.1.1
-ValidationKey: 568290800
+ValidationKey: 568475310
 VignetteBuilder: knitr

--- a/R/as.quitte.R
+++ b/R/as.quitte.R
@@ -18,7 +18,8 @@
 #' @keywords classes
 #' @importFrom reshape2 melt
 #' @importFrom forcats fct_explicit_na
-
+#' @importFrom tibble as_tibble
+#'
 #' @export
 as.quitte <- function(x, periodClass = 'integer', addNA=FALSE, na.rm=FALSE) {
     UseMethod('as.quitte', x)
@@ -217,7 +218,7 @@ as.quitte.magpie <- function(x, periodClass = "integer", addNA = FALSE,
       x <- qaddNA(x)
     if (na.rm)
       x <- x[!is.na(x$value), ]
-    x <- tbl_df(x)
+    x <- as_tibble(x)
 
     class(x) <- c('quitte', class(x))
 

--- a/R/inline.data.frame.R
+++ b/R/inline.data.frame.R
@@ -21,6 +21,7 @@
 #'
 #' @import dplyr
 #' @import utils
+#' @importFrom tibble as_tibble
 #'
 #' @export
 inline.data.frame <- function(..., sep = ";", quote = "") {
@@ -47,5 +48,5 @@ inline.data.frame <- function(..., sep = ";", quote = "") {
         read.table(header = TRUE, sep = sep, quote = quote, comment.char = "",
                    strip.white = TRUE, stringsAsFactors = FALSE,
                    check.names = FALSE) %>%
-        tbl_df()
+        as_tibble()
 }

--- a/R/read.gdx.R
+++ b/R/read.gdx.R
@@ -16,6 +16,8 @@
 #' @return quitte data frame
 #' @author Michaja Pehl
 #'
+#' @importFrom tibble as_tibble
+#'
 #' @export
 read.gdx <- function(gdxName, requestList.name, fields = "l", colNames = NULL,
                      factors = TRUE, squeeze = TRUE) {
@@ -113,7 +115,7 @@ read.gdx <- function(gdxName, requestList.name, fields = "l", colNames = NULL,
         names(data) <- colNames
     }
 
-    data <- tbl_df(data.frame(data))
+    data <- as_tibble(data.frame(data))
 
     if (!factors) {
         data <- data %>%

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Bits and pieces of code to use with quitte-style data frames
 
-R package **quitte**, version **0.3080.0**
+R package **quitte**, version **0.3081.0**
 
   
 
@@ -47,9 +47,8 @@ In case of questions / problems please contact Michaja Pehl <michaja.pehl@pik-po
 
 To cite package **quitte** in publications use:
 
-Pehl M, Bauer N, Hilaire J, Levesque A, Luderer G, Schultes A, Dietrich J (2020). _quitte: Bits
-and pieces of code to use with quitte-style data frames_. R package version 0.3080.0, <URL:
-https://CRAN.R-project.org/package=quitte>.
+Pehl M, Bauer N, Hilaire J, Levesque A, Luderer G, Schultes A, Dietrich J (2020). _quitte: Bits and pieces of code
+to use with quitte-style data frames_. R package version 0.3081.0, <URL: https://CRAN.R-project.org/package=quitte>.
 
 A BibTeX entry for LaTeX users is
 
@@ -58,7 +57,7 @@ A BibTeX entry for LaTeX users is
   title = {quitte: Bits and pieces of code to use with quitte-style data frames},
   author = {Michaja Pehl and Nico Bauer and Jérôme Hilaire and Antoine Levesque and Gunnar Luderer and Anselm Schultes and Jan Philipp Dietrich},
   year = {2020},
-  note = {R package version 0.3080.0},
+  note = {R package version 0.3081.0},
   url = {https://CRAN.R-project.org/package=quitte},
 }
 ```


### PR DESCRIPTION
This should get rid of the following life-cycle warning:

Warning message:
`tbl_df()` is deprecated as of dplyr 1.0.0.
Please use `tibble::as_tibble()` instead.

All checks passed.