### PR TITLE
bugfix variable/value args were not evaluated correctly

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,7 +1,8 @@
-ValidationKey: '579030880'
+ValidationKey: '582292136'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'
 AcceptedNotes: unable to verify current time
 AutocreateReadme: yes
 UseGithubActions: yes
+allowLinterWarnings: yes

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "quitte: Bits and pieces of code to use with quitte-style data frames",
-  "version": "0.3088.0",
+  "version": "0.3088.1",
   "description": "<p>A collection of functions for easily dealing with\n    quitte-style data frames, doing multi-model comparisons and plots.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,8 +2,8 @@ Encoding: UTF-8
 Package: quitte
 Type: Package
 Title: Bits and pieces of code to use with quitte-style data frames
-Version: 0.3088.0
-Date: 2021-05-04
+Version: 0.3088.1
+Date: 2021-08-17
 Authors@R: c(person("Michaja", "Pehl", role = c("aut", "cre"),
 		            email = "pehl@pik-potsdam.de"),
 		     person("Nico", "Bauer", role = "aut",

--- a/R/calc_addVariable.R
+++ b/R/calc_addVariable.R
@@ -193,7 +193,7 @@ calc_addVariable_ <- function(data, .dots, na.rm = TRUE,
 
   # ---- calculation ----
   data_ <- data_ %>%
-    pivot_wider(names_from = variable, values_from = value)
+    pivot_wider(names_from = sym(variable), values_from = sym(value))
 
   for (i in 1:length(.dots))
   {

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Bits and pieces of code to use with quitte-style data frames
 
-R package **quitte**, version **0.3088.0**
+R package **quitte**, version **0.3088.1**
 
-[![CRAN status](https://www.r-pkg.org/badges/version/quitte)](https://cran.r-project.org/package=quitte)   [![R build status](https://pik.github.com/pik-piam/quitte/workflows/check/badge.svg)](https://pik.github.com/pik-piam/quitte/actions) [![codecov](https://codecov.io/gh/pik-piam/quitte/branch/master/graph/badge.svg)](https://codecov.io/gh/pik-piam/quitte)
+[![CRAN status](https://www.r-pkg.org/badges/version/quitte)](https://cran.r-project.org/package=quitte)   [![R build status](https://github.com/pik-piam/quitte/workflows/check/badge.svg)](https://github.com/pik-piam/quitte/actions) [![codecov](https://codecov.io/gh/pik-piam/quitte/branch/master/graph/badge.svg)](https://codecov.io/gh/pik-piam/quitte) [![r-universe](https://pik-piam.r-universe.dev/badges/quitte)](https://pik-piam.r-universe.dev/ui#builds)
 
 ## Purpose and Functionality
 
@@ -47,10 +47,7 @@ In case of questions / problems please contact Michaja Pehl <michaja.pehl@pik-po
 
 To cite package **quitte** in publications use:
 
-Pehl M, Bauer N, Hilaire J, Levesque A, Luderer G, Schultes A, Dietrich
-J (2021). _quitte: Bits and pieces of code to use with quitte-style
-data frames_. R package version 0.3088.0, <URL:
-https://CRAN.R-project.org/package=quitte>.
+Pehl M, Bauer N, Hilaire J, Levesque A, Luderer G, Schultes A, Dietrich J (2021). _quitte: Bits and pieces of code to use with quitte-style data frames_. R package version 0.3088.1, <URL: https://CRAN.R-project.org/package=quitte>.
 
 A BibTeX entry for LaTeX users is
 
@@ -59,7 +56,7 @@ A BibTeX entry for LaTeX users is
   title = {quitte: Bits and pieces of code to use with quitte-style data frames},
   author = {Michaja Pehl and Nico Bauer and Jérôme Hilaire and Antoine Levesque and Gunnar Luderer and Anselm Schultes and Jan Philipp Dietrich},
   year = {2021},
-  note = {R package version 0.3088.0},
+  note = {R package version 0.3088.1},
   url = {https://CRAN.R-project.org/package=quitte},
 }
 ```

--- a/vignettes/quitte-data-analysis.Rmd
+++ b/vignettes/quitte-data-analysis.Rmd
@@ -4,7 +4,7 @@ author: "Michaja Pehl"
 date: "`r as.Date(file.mtime('./quitte-data-analysis.Rmd'))`"
 output: rmarkdown::html_vignette
 vignette: >
-  %\VignetteIndexEntry{quitte-data-analysis}
+  %\VignetteIndexEntry{REMIND/IAM Data Analysis Using quitte}
   %\VignetteEncoding{UTF-8}
   %\VignetteEngine{knitr::rmarkdown}
 editor_options: 


### PR DESCRIPTION
`pivot_wider` parameters `names_from` and `values_from` use tidy evaluation, so strings must be wrapped in `sym` to be evaluated correctly.
The bug that is fixed with this PR can be reproduced with the following code:
```
x <- tibble::tibble(variable = "Residential Dishwashers",
                    appendix = "reference",
                    property = "Typical Annual Energy Use (kWh/yr)",
                    efficiency = c("Installed Base", "Installed Base", "Current Standard"),
                    period = c(2009, 2015, 2017),
                    value = c(383, 347, 307))
print(x)
quitte::calc_addVariable_(x,
                          list("blub" = "`Typical Annual Energy Use (kWh/yr)`"),
                          variable = "property",
                          value = "period")
```