### PR TITLE
fix warning in as.quitte when loading several files

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '604077650'
+ValidationKey: '604097055'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "quitte: Bits and pieces of code to use with quitte-style data frames",
-  "version": "0.3113.0",
+  "version": "0.3113.1",
   "description": "<p>A collection of functions for easily dealing with\n    quitte-style data frames, doing multi-model comparisons and plots.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: quitte
 Title: Bits and pieces of code to use with quitte-style data frames
-Version: 0.3113.0
+Version: 0.3113.1
 Date: 2023-02-17
 Authors@R: c(
     person("Michaja", "Pehl", , "pehl@pik-potsdam.de", role = c("aut", "cre")),

--- a/Makefile
+++ b/Makefile
@@ -11,33 +11,35 @@ HELP_PARSING = 'm <- readLines("Makefile");\
 help:           ## Show this help.
 	@Rscript -e $(HELP_PARSING)
 
-build:          ## Build the package using lucode2::buildLibrary()
+build:          ## Build the package using lucode2::buildLibrary().
 	Rscript -e 'lucode2::buildLibrary()'
 
 check:          ## Build documentation and vignettes, run testthat tests,
-                ## and check if code etiquette is followed using lucode2::check()
+                ## and check if code etiquette is followed using lucode2::check().
 	Rscript -e 'lucode2::check()'
 
 test:           ## Run testthat tests
 	Rscript -e 'devtools::test(show_report = TRUE)'
 
-lint:           ## Check if code etiquette is followed using lucode2::lint()
+lint:           ## Check if code etiquette is followed using lucode2::lint().
                 ## Only checks files you changed.
 	Rscript -e 'lucode2::lint()'
 
-lint-all:       ## Check if code etiquette is followed using lucode2::lint()
+lint-all:       ## Check if code etiquette is followed using lucode2::lint().
                 ## Checks all files.
 	Rscript -e 'lucode2::lint(".")'
 
-format:         ## Apply auto-formatting to changed files and lint afterwards
+format:         ## Apply auto-formatting to changed files and lint afterwards.
 	Rscript -e 'lucode2::autoFormat()'
 
-format-all:     ## Apply auto-formatting to all files and lint afterwards
+format-all:     ## Apply auto-formatting to all files and lint afterwards.
 	Rscript -e 'lucode2::autoFormat(files=list.files("./R", full.names = TRUE, pattern = "\\.R"))'
 
-install:        ## Install the package locally via devtools::install()
-	Rscript -e 'devtools::install(upgrade = "never")'
+install:        ## Install the package locally via devtools::install() after
+                ## generating NAMESPACE and docs (see docs target).
+	Rscript -e 'roxygen2::roxygenize(); devtools::install(upgrade = "never")'
 
-docs:           ## Generate the package documentation (man/*.Rd files) via roxygen2::roxygenize(),
-                ## view the generated documentation with `?package::function`
+docs:           ## Generate the package documentation (man/*.Rd files) and
+                ## NAMESPACE via roxygen2::roxygenize(), view the generated
+                ## documentation with `?package::function`.
 	Rscript -e 'roxygen2::roxygenize()'

--- a/R/as.quitte.R
+++ b/R/as.quitte.R
@@ -28,8 +28,7 @@ as.quitte <- function(x, periodClass = "integer", addNA = FALSE, na.rm = FALSE) 
 
 #' @export
 as.quitte.character <- function(x, periodClass = "integer", addNA = FALSE, na.rm = FALSE) { # nolint
-    if (file.exists(x) &
-        grepl("\\.(mif|csv|xlsx)$", x))
+    if (all(file.exists(x) & grepl("\\.(mif|csv|xlsx)$", x)))
         return(as.quitte(read.quitte(x), periodClass =
                                   periodClass, addNA = addNA, na.rm = na.rm))
     stop(

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Bits and pieces of code to use with quitte-style data frames
 
-R package **quitte**, version **0.3113.0**
+R package **quitte**, version **0.3113.1**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/quitte)](https://cran.r-project.org/package=quitte)  [![R build status](https://github.com/pik-piam/quitte/workflows/check/badge.svg)](https://github.com/pik-piam/quitte/actions) [![codecov](https://codecov.io/gh/pik-piam/quitte/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/quitte) [![r-universe](https://pik-piam.r-universe.dev/badges/quitte)](https://pik-piam.r-universe.dev/builds)
 
@@ -47,7 +47,7 @@ In case of questions / problems please contact Michaja Pehl <michaja.pehl@pik-po
 
 To cite package **quitte** in publications use:
 
-Pehl M, Bauer N, Hilaire J, Levesque A, Luderer G, Schultes A, Dietrich J, Richters O (2023). _quitte: Bits and pieces of code to use with quitte-style data frames_. R package version 0.3113.0, <https://github.com/pik-piam/quitte>.
+Pehl M, Bauer N, Hilaire J, Levesque A, Luderer G, Schultes A, Dietrich J, Richters O (2023). _quitte: Bits and pieces of code to use with quitte-style data frames_. R package version 0.3113.1, <URL: https://github.com/pik-piam/quitte>.
 
 A BibTeX entry for LaTeX users is
 
@@ -56,7 +56,7 @@ A BibTeX entry for LaTeX users is
   title = {quitte: Bits and pieces of code to use with quitte-style data frames},
   author = {Michaja Pehl and Nico Bauer and Jérôme Hilaire and Antoine Levesque and Gunnar Luderer and Anselm Schultes and Jan Philipp Dietrich and Oliver Richters},
   year = {2023},
-  note = {R package version 0.3113.0},
+  note = {R package version 0.3113.1},
   url = {https://github.com/pik-piam/quitte},
 }
 ```

--- a/man/calc_addVariable.Rd
+++ b/man/calc_addVariable.Rd
@@ -13,7 +13,7 @@ calc_addVariable(
   completeMissing = FALSE,
   only.new = FALSE,
   variable = variable,
-  unit = NA,
+  unit = unit,
   value = value
 )
 
@@ -24,7 +24,7 @@ calc_addVariable_(
   completeMissing = FALSE,
   only.new = FALSE,
   variable = "variable",
-  unit = NA,
+  unit = "unit",
   value = "value"
 )
 }
@@ -37,19 +37,24 @@ calc_addVariable_(
 be of length equal to \code{...} or of length one (in which case all new
 variables receive the same unit).}
 
-\item{na.rm}{If \code{TRUE} (the default), remove items calculated as \code{NA}.}
+\item{na.rm}{If \code{TRUE} (the default), remove items calculated as \code{NA}.  This
+is generally the case for all calculations involving \code{NA} values, and all
+calculations involving missing variables.  See \code{completeMissing} parameter.}
 
 \item{completeMissing}{If \code{TRUE}, implicitly missing data, i.e. missing
-combinations of input data, are filled up with 0 before the calculation.
-Alternatively, you can provide a character vector with the names of the
-columns to be expanded.  Can interfere with \code{na.rm}.}
+combinations of input data, are filled up with 0 before the calculation,
+and they are therefore not computed as \code{NA} (and potentially removed from
+the output).  Make sure \code{0} is a sensible value for your calculations, else
+complete missing values manually.  Defaults to \code{FALSE}.}
 
 \item{only.new}{If \code{FALSE} (the default), add new variables to existing
 ones.  If \code{TRUE}, return only new variables.}
 
 \item{variable}{Column name of variables.  Defaults to \code{"variable"}.}
 
-\item{unit}{Column name of units.  Defaults to \code{"unit"}.}
+\item{unit}{Column name of units.  Defaults to \code{"unit"}.  Ignored if no
+column with the same name is in \code{data} (e.g. data frames without unit
+column).}
 
 \item{value}{Column name of values.  Defaults to \code{"value"}.}
 
@@ -63,9 +68,10 @@ Calculate new variables from existing ones, using generic formulas.
 }
 \details{
 \code{...} is a list of name-value pairs with the general format
-\preformatted{
-"lhs" = "rhs + calculations - formula", "`lhs 2`" = "lhs / `rhs 2`"
-}
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{"lhs" = "rhs + calculations - formula", "`lhs 2`" = "lhs / `rhs 2`"
+}\if{html}{\out{</div>}}
+
 where \code{lhs} are the names of new variables to be calculated and
 \code{rhs} are the variables to calculate from. If \code{lhs} and \code{rhs}
 are no proper \emph{identifiers}, they need to be quoted (see
@@ -75,15 +81,16 @@ If the new variables should have units, set \code{units} appropriately.
 
 \code{.dots} is a named list of strings denoting formulas and optionally
 units. The general format is
-\preformatted{
-list("`lhs 1`" = "`rhs` / `calculation`",
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{list("`lhs 1`" = "`rhs` / `calculation`",
      "`lhs 2`" = "sin(`rhs 2`)")
-}
+}\if{html}{\out{</div>}}
 
 Units are optionally included with the formulas in a vector like
-\preformatted{
-list("`lhs w/ unit`" = c("`rhs 1` + `rhs 2`", "rhs unit")
-}
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{list("`lhs w/ unit`" = c("`rhs 1` + `rhs 2`", "rhs unit")
+}\if{html}{\out{</div>}}
+
 Units do not require quoting.
 
 \code{...} and \code{.dots} are processed in order, and variables already


### PR DESCRIPTION
Running `as.quitte(c("onefile.csv", "twofile.csv"))` works, but raises a warning:
```
Warning message:
In if (file.exists(x) & grepl("\\.(mif|csv|xlsx)$", x)) return(as.quitte(read.quitte(x),  :
  the condition has length > 1 and only the first element will be used
```
After this PR, no warning is raised anymore.