### PR TITLE
add explicit error if calc_addVariables() is missing some variables completely

### DIFF
--- a/R/calc_addVariable.R
+++ b/R/calc_addVariable.R
@@ -174,6 +174,15 @@ calc_addVariable_ <- function(data, .dots, na.rm = TRUE,
 
   # calculate new variables ----
   for (i in seq_along(.dots)) {
+    missing_rhs_variables <- setdiff(.dots[[i]]$variables,
+                                     data_work[[variable]])
+    if (0 < length(missing_rhs_variables)) {
+      stop(length(missing_rhs_variables), ' variable',
+           ifelse(1 < length(missing_rhs_variables), 's are', ' is'),
+           ' missing for the calculation:\n',
+           paste(paste0('`', missing_rhs_variables, '`'), collapse = '\n'))
+    }
+
     data_work <- bind_rows(
       data_work %>%
         filter(.dots[[i]]$name != !!sym(variable)),

--- a/tests/testthat/test-calc_addVariable.R
+++ b/tests/testthat/test-calc_addVariable.R
@@ -141,3 +141,12 @@ test_that(
         select(-unit)
     )}
 )
+
+test_that(
+  desc = 'completly missing variables yield an error',
+  code = {
+    expect_error(
+      object = tibble(variable = 'A', value = 1) %>%
+        calc_addVariable('C' = 'A + B'),
+      regexp = '1 variable is missing for the calculation:\n`B`')
+  })


### PR DESCRIPTION
Looks like
```
df.plot.decomb %>% 
    filter('COFFEE 1.3' != model) %>% 
    calc_addVariable(
        "`Final Energy|Industry|Iron and Steel|Residual Fossil Fuel`" =
            " `Final Energy|Industry|Iron and Steel|Solids|Coal`
            + `Final Energy|Industry|Iron and Steel|Liquids|Fossil`
            + `Final Energy|Industry|Iron and Steel|Gases|Fossil`
            + `Final Energy|Non-Energy Use|Iron and Steel|Solids|Coal`
            + `Final Energy|Non-Energy Use|Iron and Steel|Liquids|Fossil`
            + `Final Energy|Non-Energy Use|Iron and Steel|Gases|Fossil`",
        units = "EJ / yr", completeMissing = TRUE, only.new = TRUE)
```
> ```
> Error in calc_addVariable_(data, .dots, na.rm, completeMissing, only.new, : 
> 3 variables are missing for the calculation:
>  `Final Energy|Non-Energy Use|Iron and Steel|Solids|Coal`
>  `Final Energy|Non-Energy Use|Iron and Steel|Liquids|Fossil`
>  `Final Energy|Non-Energy Use|Iron and Steel|Gases|Fossil`
> ```