### PR TITLE
let as.quitte support xls, not only xlsx

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '604552308'
+ValidationKey: '604883057'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "quitte: Bits and pieces of code to use with quitte-style data frames",
-  "version": "0.3113.2",
+  "version": "0.3113.3",
   "description": "<p>A collection of functions for easily dealing with\n    quitte-style data frames, doing multi-model comparisons and plots.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: quitte
 Title: Bits and pieces of code to use with quitte-style data frames
-Version: 0.3113.2
-Date: 2023-03-03
+Version: 0.3113.3
+Date: 2023-03-13
 Authors@R: c(
     person("Michaja", "Pehl", , "pehl@pik-potsdam.de", role = c("aut", "cre")),
     person("Nico", "Bauer", , "nicolasb@pik-potsdam.de", role = "aut"),

--- a/R/as.quitte.R
+++ b/R/as.quitte.R
@@ -28,7 +28,7 @@ as.quitte <- function(x, periodClass = "integer", addNA = FALSE, na.rm = FALSE) 
 
 #' @export
 as.quitte.character <- function(x, periodClass = "integer", addNA = FALSE, na.rm = FALSE) { # nolint
-    if (all(file.exists(x) & grepl("\\.(mif|csv|xlsx)$", x)))
+    if (all(file.exists(x) & grepl("\\.(mif|csv|xlsx?)$", x)))
         return(as.quitte(read.quitte(x), periodClass =
                                   periodClass, addNA = addNA, na.rm = na.rm))
     stop(

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Bits and pieces of code to use with quitte-style data frames
 
-R package **quitte**, version **0.3113.2**
+R package **quitte**, version **0.3113.3**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/quitte)](https://cran.r-project.org/package=quitte)  [![R build status](https://github.com/pik-piam/quitte/workflows/check/badge.svg)](https://github.com/pik-piam/quitte/actions) [![codecov](https://codecov.io/gh/pik-piam/quitte/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/quitte) [![r-universe](https://pik-piam.r-universe.dev/badges/quitte)](https://pik-piam.r-universe.dev/builds)
 
@@ -47,7 +47,7 @@ In case of questions / problems please contact Michaja Pehl <michaja.pehl@pik-po
 
 To cite package **quitte** in publications use:
 
-Pehl M, Bauer N, Hilaire J, Levesque A, Luderer G, Schultes A, Dietrich J, Richters O (2023). _quitte: Bits and pieces of code to use with quitte-style data frames_. R package version 0.3113.2, <https://github.com/pik-piam/quitte>.
+Pehl M, Bauer N, Hilaire J, Levesque A, Luderer G, Schultes A, Dietrich J, Richters O (2023). _quitte: Bits and pieces of code to use with quitte-style data frames_. R package version 0.3113.3, <URL: https://github.com/pik-piam/quitte>.
 
 A BibTeX entry for LaTeX users is
 
@@ -56,7 +56,7 @@ A BibTeX entry for LaTeX users is
   title = {quitte: Bits and pieces of code to use with quitte-style data frames},
   author = {Michaja Pehl and Nico Bauer and Jérôme Hilaire and Antoine Levesque and Gunnar Luderer and Anselm Schultes and Jan Philipp Dietrich and Oliver Richters},
   year = {2023},
-  note = {R package version 0.3113.2},
+  note = {R package version 0.3113.3},
   url = {https://github.com/pik-piam/quitte},
 }
 ```


### PR DESCRIPTION
`grepl("\\.(mif|csv|xlsx)$", x)` ->
`grepl("\\.(mif|csv|xlsx?)$", x)`

`read.quitte` can [handle it](https://github.com/pik-piam/quitte/blob/master/R/read.quitte.R#LL63C20-L63C28)