### PR TITLE
increase guess_max in read_excel to avoid values been forced to boolean

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '606841000'
+ValidationKey: '607078602'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'quitte: Bits and pieces of code to use with quitte-style data frames'
-version: 0.3116.0
-date-released: '2023-04-28'
+version: 0.3116.1
+date-released: '2023-05-05'
 abstract: A collection of functions for easily dealing with quitte-style data frames,
   doing multi-model comparisons and plots.
 authors:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: quitte
 Title: Bits and pieces of code to use with quitte-style data frames
-Version: 0.3116.0
-Date: 2023-04-28
+Version: 0.3116.1
+Date: 2023-05-05
 Authors@R: c(
     person("Michaja", "Pehl", , "pehl@pik-potsdam.de", role = c("aut", "cre")),
     person("Nico", "Bauer", , "nicolasb@pik-potsdam.de", role = "aut"),

--- a/R/read.quitte.R
+++ b/R/read.quitte.R
@@ -63,7 +63,7 @@ read.quitte <- function(file,
         default.columns  <- c("model", "scenario", "region", "variable", "unit")
 
         if (grepl("\\.xlsx?$", f)) {
-            data <- read_excel(path = f, sheet = if ('data' %in% excel_sheets(f)) 'data' else 1)
+            data <- read_excel(path = f, sheet = if ('data' %in% excel_sheets(f)) 'data' else 1, guess_max = 21474836)
             data <- pivot_longer(data, matches("^[0-9]{4}$"), names_to = 'period', values_drop_na = drop.na)
             missing.default.columns <- default.columns[! default.columns %in% tolower(colnames(data))]
             if (length(missing.default.columns) > 0) {

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Bits and pieces of code to use with quitte-style data frames
 
-R package **quitte**, version **0.3116.0**
+R package **quitte**, version **0.3116.1**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/quitte)](https://cran.r-project.org/package=quitte)  [![R build status](https://github.com/pik-piam/quitte/workflows/check/badge.svg)](https://github.com/pik-piam/quitte/actions) [![codecov](https://codecov.io/gh/pik-piam/quitte/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/quitte) [![r-universe](https://pik-piam.r-universe.dev/badges/quitte)](https://pik-piam.r-universe.dev/builds)
 
@@ -47,7 +47,7 @@ In case of questions / problems please contact Michaja Pehl <michaja.pehl@pik-po
 
 To cite package **quitte** in publications use:
 
-Pehl M, Bauer N, Hilaire J, Levesque A, Luderer G, Schultes A, Dietrich J, Richters O (2023). _quitte: Bits and pieces of code to use with quitte-style data frames_. R package version 0.3116.0, <URL: https://github.com/pik-piam/quitte>.
+Pehl M, Bauer N, Hilaire J, Levesque A, Luderer G, Schultes A, Dietrich J, Richters O (2023). _quitte: Bits and pieces of code to use with quitte-style data frames_. R package version 0.3116.1, <URL: https://github.com/pik-piam/quitte>.
 
 A BibTeX entry for LaTeX users is
 
@@ -56,7 +56,7 @@ A BibTeX entry for LaTeX users is
   title = {quitte: Bits and pieces of code to use with quitte-style data frames},
   author = {Michaja Pehl and Nico Bauer and Jérôme Hilaire and Antoine Levesque and Gunnar Luderer and Anselm Schultes and Jan Philipp Dietrich and Oliver Richters},
   year = {2023},
-  note = {R package version 0.3116.0},
+  note = {R package version 0.3116.1},
   url = {https://github.com/pik-piam/quitte},
 }
 ```


### PR DESCRIPTION
- I had a long snapshot file from IIASA, where the yearly MAGICC temperature data was below all the 5-year IAM results
- reading this file lead to 2031, 2032 etc. temperature data being forced to 1 or 0
- I spent quite some time making a minimum working example, because the error kept going away when I reduced the file length.
- Reason: `guess_max` of [read_excel](https://readxl.tidyverse.org/reference/read_excel.html) which tries to guess column type defaults to 1000, and interprets empty cells as "boolean" 😝 
- you can set it to Inf, but then it complains: `guess_max` is a very large value, setting to `21474836` to avoid exhausting memory
- So let us use 21474836 instead
- I could not see any difference in loading time