### PR TITLE
Add argument in calc_addVariable whether to overwrite existing values

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '607078602'
+ValidationKey: '607565640'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'quitte: Bits and pieces of code to use with quitte-style data frames'
-version: 0.3116.1
-date-released: '2023-05-05'
+version: 0.3117.0
+date-released: '2023-05-15'
 abstract: A collection of functions for easily dealing with quitte-style data frames,
   doing multi-model comparisons and plots.
 authors:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: quitte
 Title: Bits and pieces of code to use with quitte-style data frames
-Version: 0.3116.1
-Date: 2023-05-05
+Version: 0.3117.0
+Date: 2023-05-15
 Authors@R: c(
     person("Michaja", "Pehl", , "pehl@pik-potsdam.de", role = c("aut", "cre")),
     person("Nico", "Bauer", , "nicolasb@pik-potsdam.de", role = "aut"),

--- a/R/calc_addVariable.R
+++ b/R/calc_addVariable.R
@@ -46,6 +46,8 @@
 #'   complete missing values manually.  Defaults to `FALSE`.
 #' @param only.new If `FALSE` (the default), add new variables to existing
 #'   ones.  If `TRUE`, return only new variables.
+#' @param overwrite If `TRUE` (the default), values are overwritten if they
+#'   already exist. If `FALSE` existing values are not overwritten.
 #' @param variable Column name of variables.  Defaults to `"variable"`.
 #' @param unit Column name of units.  Defaults to `"unit"`.  Ignored if no
 #'   column with the same name is in `data` (e.g. data frames without unit
@@ -89,7 +91,8 @@
 #' @export
 calc_addVariable <- function(data, ..., units = NA, na.rm = TRUE,
                              completeMissing = FALSE, only.new = FALSE,
-                             variable = variable, unit = unit, value = value) {
+                             overwrite = TRUE, variable = variable, 
+                             unit = unit, value = value) {
 
   .dots    <- list(...)
 
@@ -108,16 +111,16 @@ calc_addVariable <- function(data, ..., units = NA, na.rm = TRUE,
   unit     <- deparse(substitute(unit))
   value    <- deparse(substitute(value))
 
-  calc_addVariable_(data, .dots, na.rm, completeMissing, only.new, variable,
-                    unit, value)
+  calc_addVariable_(data, .dots, na.rm, completeMissing, only.new, overwrite,
+                    variable, unit, value)
 }
 
 #' @export
 #' @rdname calc_addVariable
 calc_addVariable_ <- function(data, .dots, na.rm = TRUE,
                               completeMissing = FALSE, only.new = FALSE,
-                              variable = 'variable', unit = 'unit',
-                              value = 'value') {
+                              overwrite = TRUE, variable = 'variable',
+                              unit = 'unit', value = 'value') {
   . <- NULL
 
   # guardians ----
@@ -213,17 +216,32 @@ calc_addVariable_ <- function(data, .dots, na.rm = TRUE,
   if (only.new) {
     data <- data_work
   } else {
-    data <- bind_rows(
-      anti_join(
-        data,
-
-        data_work,
-
-        setdiff(.colnames, c(unit, value))
-      ),
-
-      data_work
-    )
+    
+    if (overwrite) {
+      data <- bind_rows(
+        anti_join(
+          data,
+          
+          data_work,
+          
+          setdiff(.colnames, c(unit, value))
+        ),
+        
+        data_work
+      )
+    } else {
+      data <- bind_rows(
+        anti_join(
+          data_work,
+          
+          data,
+          
+          setdiff(.colnames, c(unit, value))
+        ),
+        
+        data
+      )
+    }
   }
 
   return(data)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Bits and pieces of code to use with quitte-style data frames
 
-R package **quitte**, version **0.3116.1**
+R package **quitte**, version **0.3117.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/quitte)](https://cran.r-project.org/package=quitte)  [![R build status](https://github.com/pik-piam/quitte/workflows/check/badge.svg)](https://github.com/pik-piam/quitte/actions) [![codecov](https://codecov.io/gh/pik-piam/quitte/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/quitte) [![r-universe](https://pik-piam.r-universe.dev/badges/quitte)](https://pik-piam.r-universe.dev/builds)
 
@@ -47,7 +47,7 @@ In case of questions / problems please contact Michaja Pehl <michaja.pehl@pik-po
 
 To cite package **quitte** in publications use:
 
-Pehl M, Bauer N, Hilaire J, Levesque A, Luderer G, Schultes A, Dietrich J, Richters O (2023). _quitte: Bits and pieces of code to use with quitte-style data frames_. R package version 0.3116.1, <URL: https://github.com/pik-piam/quitte>.
+Pehl M, Bauer N, Hilaire J, Levesque A, Luderer G, Schultes A, Dietrich J, Richters O (2023). _quitte: Bits and pieces of code to use with quitte-style data frames_. R package version 0.3117.0, <https://github.com/pik-piam/quitte>.
 
 A BibTeX entry for LaTeX users is
 
@@ -56,7 +56,7 @@ A BibTeX entry for LaTeX users is
   title = {quitte: Bits and pieces of code to use with quitte-style data frames},
   author = {Michaja Pehl and Nico Bauer and Jérôme Hilaire and Antoine Levesque and Gunnar Luderer and Anselm Schultes and Jan Philipp Dietrich and Oliver Richters},
   year = {2023},
-  note = {R package version 0.3116.1},
+  note = {R package version 0.3117.0},
   url = {https://github.com/pik-piam/quitte},
 }
 ```

--- a/man/calc_addVariable.Rd
+++ b/man/calc_addVariable.Rd
@@ -12,6 +12,7 @@ calc_addVariable(
   na.rm = TRUE,
   completeMissing = FALSE,
   only.new = FALSE,
+  overwrite = TRUE,
   variable = variable,
   unit = unit,
   value = value
@@ -23,6 +24,7 @@ calc_addVariable_(
   na.rm = TRUE,
   completeMissing = FALSE,
   only.new = FALSE,
+  overwrite = TRUE,
   variable = "variable",
   unit = "unit",
   value = "value"
@@ -49,6 +51,9 @@ complete missing values manually.  Defaults to \code{FALSE}.}
 
 \item{only.new}{If \code{FALSE} (the default), add new variables to existing
 ones.  If \code{TRUE}, return only new variables.}
+
+\item{overwrite}{If \code{TRUE} (the default), values are overwritten if they
+already exist. If \code{FALSE} existing values are not overwritten.}
 
 \item{variable}{Column name of variables.  Defaults to \code{"variable"}.}
 


### PR DESCRIPTION
This PR includes an additional argument `overwrite` in the `calc_addVariable` function.

If set to `TRUE`, the default and current behaviour, values will be overwritten if they already exist.

If set to `FALSE`, values will not be overwritten if they already exist.

I found this helpful when dealing with incomplete reporting from e.g. the AR6 database, when sometimes you want to calculate a value only if it isn't reported already.

This PR should not change the default behaviour of the function.

Please check for errors as I'm certainly not a quitte expert. Thanks!