### PR TITLE
extend strtrimcommon() to trim on marker characters

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '609546170'
+ValidationKey: '609772800'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'quitte: Bits and pieces of code to use with quitte-style data frames'
-version: 0.3119.0
-date-released: '2023-07-05'
+version: 0.3120.0
+date-released: '2023-07-06'
 abstract: A collection of functions for easily dealing with quitte-style data frames,
   doing multi-model comparisons and plots.
 authors:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: quitte
 Title: Bits and pieces of code to use with quitte-style data frames
-Version: 0.3119.0
-Date: 2023-07-05
+Version: 0.3120.0
+Date: 2023-07-06
 Authors@R: c(
     person("Michaja", "Pehl", , "pehl@pik-potsdam.de", role = c("aut", "cre")),
     person("Nico", "Bauer", , "nicolasb@pik-potsdam.de", role = "aut"),

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Bits and pieces of code to use with quitte-style data frames
 
-R package **quitte**, version **0.3119.0**
+R package **quitte**, version **0.3120.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/quitte)](https://cran.r-project.org/package=quitte)  [![R build status](https://github.com/pik-piam/quitte/workflows/check/badge.svg)](https://github.com/pik-piam/quitte/actions) [![codecov](https://codecov.io/gh/pik-piam/quitte/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/quitte) [![r-universe](https://pik-piam.r-universe.dev/badges/quitte)](https://pik-piam.r-universe.dev/builds)
 
@@ -47,7 +47,7 @@ In case of questions / problems please contact Michaja Pehl <michaja.pehl@pik-po
 
 To cite package **quitte** in publications use:
 
-Pehl M, Bauer N, Hilaire J, Levesque A, Luderer G, Schultes A, Dietrich J, Richters O (2023). _quitte: Bits and pieces of code to use with quitte-style data frames_. R package version 0.3119.0, <https://github.com/pik-piam/quitte>.
+Pehl M, Bauer N, Hilaire J, Levesque A, Luderer G, Schultes A, Dietrich J, Richters O (2023). _quitte: Bits and pieces of code to use with quitte-style data frames_. R package version 0.3120.0, <https://github.com/pik-piam/quitte>.
 
 A BibTeX entry for LaTeX users is
 
@@ -56,7 +56,7 @@ A BibTeX entry for LaTeX users is
   title = {quitte: Bits and pieces of code to use with quitte-style data frames},
   author = {Michaja Pehl and Nico Bauer and Jérôme Hilaire and Antoine Levesque and Gunnar Luderer and Anselm Schultes and Jan Philipp Dietrich and Oliver Richters},
   year = {2023},
-  note = {R package version 0.3119.0},
+  note = {R package version 0.3120.0},
   url = {https://github.com/pik-piam/quitte},
 }
 ```


### PR DESCRIPTION
```
x <- c('/tmp/remind2_test-convGDX2MIF_fulldata.gdx',
       '/tmp/remind2_test-Ariadne_fulldata.gdx',
       '/tmp/remind2_test-NAVIGATE_fulldata.gdx',
       '/tmp/remind2_test-NGFS_fulldata_oneRegi.gdx',
       '/tmp/remind2_test-SHAPE_fulldata.gdx')

strtrimcommon(x, USE.NAMES = TRUE)
 /tmp/remind2_test-convGDX2MIF_fulldata.gdx      /tmp/remind2_test-Ariadne_fulldata.gdx 
                     "convGDX2MIF_fulldata"                          "Ariadne_fulldata" 
    /tmp/remind2_test-NAVIGATE_fulldata.gdx /tmp/remind2_test-NGFS_fulldata_oneRegi.gdx 
                        "NAVIGATE_fulldata"                     "NGFS_fulldata_oneRegi" 
       /tmp/remind2_test-SHAPE_fulldata.gdx 
                           "SHAPE_fulldata" 
```
```
x <- c('Some|name|with|common|text|elements',
       'Some|name|without|extra|text|elements')

strtrimcommon(x, split = '|', return.all = TRUE)
$left
[1] "Some|name"

$strings
[1] "with|common"   "without|extra"

$right
[1] "text|elements"
[Package quitte version 0.3119.0 [Index](http://127.0.0.1:36245/help/library/quitte/html/00Index.html)]
```