### PR TITLE
allow to use read.snapshot without filtering, and to pass filter.function

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '614424230'
+ValidationKey: '614443879'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'quitte: Bits and pieces of code to use with quitte-style data frames'
-version: 0.3127.0
+version: 0.3127.1
 date-released: '2023-10-19'
 abstract: A collection of functions for easily dealing with quitte-style data frames,
   doing multi-model comparisons and plots.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: quitte
 Title: Bits and pieces of code to use with quitte-style data frames
-Version: 0.3127.0
+Version: 0.3127.1
 Date: 2023-10-19
 Authors@R: c(
     person("Michaja", "Pehl", , "pehl@pik-potsdam.de", role = c("aut", "cre")),

--- a/R/read.snapshot.R
+++ b/R/read.snapshot.R
@@ -25,18 +25,19 @@ read.snapshot <- function(file, keep = list()) {
   if (length(unknowntype) > 0) {
     stop("Unknown types to be kept: ", toString(unknowntype))
   }
-  testcommand <- c("grep", "head", "tail", "sed")
-  exitcodes <- suppressWarnings(
-      sapply(paste(testcommand, '--version'), system,
-             ignore.stdout = TRUE, ignore.stderr = TRUE))
-  if (any(0 != exitcodes)) {
-      stop(paste(paste0('`', testcommand[0 != exitcodes], '`', collapse = ', '),
-                "are not available system commands, please use 'read.quitte'."))
-  }
 
   # temporary file
   tmpfile <- tempfile(pattern = "data", fileext = ".csv")
   if (length(setdiff(names(keep), "period")) > 0) {
+    # check whether system commands are supported
+    testcommand <- c("grep", "head", "tail", "sed")
+    exitcodes <- suppressWarnings(
+        sapply(paste(testcommand, '--version'), system,
+               ignore.stdout = TRUE, ignore.stderr = TRUE))
+    if (any(0 != exitcodes)) {
+        stop(paste(paste0('`', testcommand[0 != exitcodes], '`', collapse = ', '),
+                  "are not available system commands, please use 'read.quitte'."))
+    }
     # always keep first lines of original file (comments, colnames), grep in the rest
     alwayskeep <- 20
     system(paste("head -n", alwayskeep, file, ">", tmpfile))

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Bits and pieces of code to use with quitte-style data frames
 
-R package **quitte**, version **0.3127.0**
+R package **quitte**, version **0.3127.1**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/quitte)](https://cran.r-project.org/package=quitte)  [![R build status](https://github.com/pik-piam/quitte/workflows/check/badge.svg)](https://github.com/pik-piam/quitte/actions) [![codecov](https://codecov.io/gh/pik-piam/quitte/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/quitte) [![r-universe](https://pik-piam.r-universe.dev/badges/quitte)](https://pik-piam.r-universe.dev/builds)
 
@@ -47,7 +47,7 @@ In case of questions / problems please contact Michaja Pehl <michaja.pehl@pik-po
 
 To cite package **quitte** in publications use:
 
-Pehl M, Bauer N, Hilaire J, Levesque A, Luderer G, Schultes A, Dietrich J, Richters O (2023). _quitte: Bits and pieces of code to use with quitte-style data frames_. R package version 0.3127.0, <URL: https://github.com/pik-piam/quitte>.
+Pehl M, Bauer N, Hilaire J, Levesque A, Luderer G, Schultes A, Dietrich J, Richters O (2023). _quitte: Bits and pieces of code to use with quitte-style data frames_. R package version 0.3127.1, <URL: https://github.com/pik-piam/quitte>.
 
 A BibTeX entry for LaTeX users is
 
@@ -56,7 +56,7 @@ A BibTeX entry for LaTeX users is
   title = {quitte: Bits and pieces of code to use with quitte-style data frames},
   author = {Michaja Pehl and Nico Bauer and Jérôme Hilaire and Antoine Levesque and Gunnar Luderer and Anselm Schultes and Jan Philipp Dietrich and Oliver Richters},
   year = {2023},
-  note = {R package version 0.3127.0},
+  note = {R package version 0.3127.1},
   url = {https://github.com/pik-piam/quitte},
 }
 ```

--- a/tests/testthat/test-read.snapshot.R
+++ b/tests/testthat/test-read.snapshot.R
@@ -37,7 +37,11 @@ test_that("read.snapshot works", {
     expect_equal(droplevels(dplyr::filter(qe, period %in% p)),
                  read.snapshot(tmpfile, list(period = p)))
   }
-  # test all jointly with last setting
-  expect_equal(droplevels(dplyr::filter(qe, period %in% p, variable %in% v, region %in% r, scenario %in% s)),
-               read.snapshot(tmpfile, list(period = p, variable = v, region = r, scenario = s)))
+  # test all jointly with last setting, test passing of filter.function
+  filter.function <- function(x) droplevels(dplyr::filter(x, period %in% p, variable %in% v, region %in% r, scenario %in% s))
+  snapshotdata <- read.snapshot(tmpfile, list(period = p, variable = v, region = r, scenario = s))
+  expect_equal(filter.function(qe),
+               snapshotdata)
+  expect_equal(read.snapshot(tmpfile, filter.function = filter.function),
+               snapshotdata)
 })


### PR DESCRIPTION
- if you don't supply a filter but just want to profit from the correct `quote` and `na` settings, don't fail if `grep`, `head` and `tail` are not available, but just read it
- allow to pass a `filter.function` to read.quitte, and transform the list-based filtering into filter function
- I took out the temperature variable, because somehow `read.quitte` on Windows transforms `°C` from the mocked IIASA snapshot mif file written with `write.table` into `<U+00B0>C` and I don't want to debug that… Writing with `write.mif` is fine, so no need to worry.