### PR TITLE
fix read.snapshot documentation, read entire snapshot if grep goes wrong

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '614443879'
+ValidationKey: '614494800'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'quitte: Bits and pieces of code to use with quitte-style data frames'
-version: 0.3127.1
-date-released: '2023-10-19'
+version: 0.3127.2
+date-released: '2023-10-20'
 abstract: A collection of functions for easily dealing with quitte-style data frames,
   doing multi-model comparisons and plots.
 authors:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: quitte
 Title: Bits and pieces of code to use with quitte-style data frames
-Version: 0.3127.1
-Date: 2023-10-19
+Version: 0.3127.2
+Date: 2023-10-20
 Authors@R: c(
     person("Michaja", "Pehl", , "pehl@pik-potsdam.de", role = c("aut", "cre")),
     person("Nico", "Bauer", , "nicolasb@pik-potsdam.de", role = "aut"),

--- a/R/read.snapshot.R
+++ b/R/read.snapshot.R
@@ -43,7 +43,7 @@ read.snapshot <- function(file, keep = list(), filter.function = NULL) {
                ignore.stdout = TRUE, ignore.stderr = TRUE))
     if (any(0 != exitcodes)) {
         stop(paste(paste0('`', testcommand[0 != exitcodes], '`', collapse = ', '),
-                  "are not available system commands, please use 'read.quitte'."))
+                  "are not available system commands, please only use 'filter.function' for filtering."))
     }
     # always keep first lines of original file (comments, colnames), grep in the rest
     alwayskeep <- 20

--- a/R/read.snapshot.R
+++ b/R/read.snapshot.R
@@ -37,33 +37,33 @@ read.snapshot <- function(file, keep = list(), filter.function = NULL) {
   tmpfile <- tempfile(pattern = "data", fileext = ".csv")
   if (length(setdiff(names(keep), "period")) > 0) {
     # check whether system commands are supported
-    testcommand <- c("grep", "head", "tail", "sed")
-    exitcodes <- suppressWarnings(
-        sapply(paste(testcommand, '--version'), system,
-               ignore.stdout = TRUE, ignore.stderr = TRUE))
-    if (any(0 != exitcodes)) {
-        stop(paste(paste0('`', testcommand[0 != exitcodes], '`', collapse = ', '),
-                  "are not available system commands, please only use 'filter.function' for filtering."))
+    testcommand <- c("grep", "head", "tail")
+    notavailable <- Sys.which(testcommand) == ""
+    if (any(notavailable)) {
+        message(paste(paste0('`', testcommand[notavailable], '`', collapse = ', '),
+                "are not available system commands, so the entire file is read."))
+    } else {
+      # always keep first lines of original file (comments, colnames), grep in the rest
+      alwayskeep <- 20
+      system(paste("head -n", alwayskeep, file, ">", tmpfile))
+      # the goal of the next lines is to grep one after the other through the elements of keep
+      # keep = list(variable = "GDP|PPP", region = c("World", "FRA")) should get you
+      # | grep -E '(GDP\|PPP)' | grep -E '(World|FRA)'
+      # 1. escape | in variable names and do not grep for period
+      cleanup <- function(x) {
+        x <- gsub("[^A-Za-z0-9\\| ]", ".", x)
+        x <- gsub("|", "\\|", x, fixed = TRUE)
+      }
+      keepescaped <- lapply(keep[setdiff(names(keep), "period")], cleanup)
+      # 2. collapse each element with a |
+      keepcollapsed <- unlist(lapply(keepescaped, paste0, collapse = "|"))
+      # generate a grep -E statement for each element of keep list
+      greptext <- paste0(" | grep -E '(", keepcollapsed, ")'", collapse = "")
+      command <- paste0("tail -n +", (alwayskeep + 1), " ", file, greptext, " >> ", tmpfile)
+      system(command)
     }
-    # always keep first lines of original file (comments, colnames), grep in the rest
-    alwayskeep <- 20
-    system(paste("head -n", alwayskeep, file, ">", tmpfile))
-    # the goal of the next lines is to grep one after the other through the elements of keep
-    # keep = list(variable = "GDP|PPP", region = c("World", "FRA")) should get you
-    # | grep -E '(GDP\|PPP)' | grep -E '(World|FRA)'
-    # 1. escape | in variable names and do not grep for period
-    cleanup <- function(x) {
-      x <- gsub("[^A-Za-z0-9\\| ]", ".", x)
-      x <- gsub("|", "\\|", x, fixed = TRUE)        
-    }
-    keepescaped <- lapply(keep[setdiff(names(keep), "period")], cleanup)
-    # 2. collapse each element with a |
-    keepcollapsed <- unlist(lapply(keepescaped, paste0, collapse = "|"))
-    # generate a grep -E statement for each element of keep list
-    greptext <- paste0(" | grep -E '(", keepcollapsed, ")'", collapse = "")
-    command <- paste0("tail -n +", (alwayskeep + 1), " ", file, greptext, " >> ", tmpfile)
-    system(command)
-  } else {
+  }
+  if (! file.exists(tmpfile)) { # if either system commands do not exist or something went wrong
     file.copy(file, tmpfile, overwrite = TRUE)
   }
   joinedfilter <- function(data) {

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Bits and pieces of code to use with quitte-style data frames
 
-R package **quitte**, version **0.3127.1**
+R package **quitte**, version **0.3127.2**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/quitte)](https://cran.r-project.org/package=quitte)  [![R build status](https://github.com/pik-piam/quitte/workflows/check/badge.svg)](https://github.com/pik-piam/quitte/actions) [![codecov](https://codecov.io/gh/pik-piam/quitte/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/quitte) [![r-universe](https://pik-piam.r-universe.dev/badges/quitte)](https://pik-piam.r-universe.dev/builds)
 
@@ -47,7 +47,7 @@ In case of questions / problems please contact Michaja Pehl <michaja.pehl@pik-po
 
 To cite package **quitte** in publications use:
 
-Pehl M, Bauer N, Hilaire J, Levesque A, Luderer G, Schultes A, Dietrich J, Richters O (2023). _quitte: Bits and pieces of code to use with quitte-style data frames_. R package version 0.3127.1, <URL: https://github.com/pik-piam/quitte>.
+Pehl M, Bauer N, Hilaire J, Levesque A, Luderer G, Schultes A, Dietrich J, Richters O (2023). _quitte: Bits and pieces of code to use with quitte-style data frames_. R package version 0.3127.2, <URL: https://github.com/pik-piam/quitte>.
 
 A BibTeX entry for LaTeX users is
 
@@ -56,7 +56,7 @@ A BibTeX entry for LaTeX users is
   title = {quitte: Bits and pieces of code to use with quitte-style data frames},
   author = {Michaja Pehl and Nico Bauer and Jérôme Hilaire and Antoine Levesque and Gunnar Luderer and Anselm Schultes and Jan Philipp Dietrich and Oliver Richters},
   year = {2023},
-  note = {R package version 0.3127.1},
+  note = {R package version 0.3127.2},
   url = {https://github.com/pik-piam/quitte},
 }
 ```

--- a/man/read.snapshot.Rd
+++ b/man/read.snapshot.Rd
@@ -7,12 +7,16 @@ filtering the data. This function is helpful if the csv file is large and R runs
 of memory loading it completely. This function requires head, tail and grep on your system.
 If not supported, use read.quitte().}
 \usage{
-read.snapshot(file, keep = list())
+read.snapshot(file, keep = list(), filter.function = NULL)
 }
 \arguments{
 \item{file}{Path of single IAMC-style .csv/.mif file}
 
-\item{keep}{list with quitte columns as names and data points that should be kept.}
+\item{keep}{list with quitte columns as names and data points that should be kept. Using 'grep',
+this list is used to extract the data before reading it into R. The more you restrict the data here,
+the faster the data is read.}
+
+\item{filter.function}{A function used to filter data during read, see read.quitte description.}
 }
 \value{
 A quitte data frame.

--- a/tests/testthat/test-read.snapshot.R
+++ b/tests/testthat/test-read.snapshot.R
@@ -10,14 +10,11 @@ test_that("read.snapshot works", {
               eol = "\n", na = "", dec = ".", row.names = FALSE,
               col.names = TRUE) # mimick IIASA snapshot format
   expect_equal(qe, read.snapshot(tmpfile))
-  fails <- tryCatch(read.snapshot(tmpfile, list(region = head(levels(qe$region), 1))),
-                    error = function(e) { paste(e) })
-  if (is.character(fails) && length(fails) == 1 && grepl("not available system commands", fails)) {
-    skip(paste0(gsub("Error in ", "", gsub(", pleas.*", "", fails)), ", skipping tests."))
+  if (Sys.which("sed") != "") {
+    system(paste("sed -i 's/GCAM/\"GCAM\"/g;'", tmpfile))
+    system(paste("sed -i 's/Delayed transition/\"Delayed transition\"/g;'", tmpfile))
   }
-  system(paste("sed -i 's/GCAM/\"GCAM\"/g;'", tmpfile))
-  system(paste("sed -i 's/Delayed transition/\"Delayed transition\"/g;'", tmpfile))
-  rtests <- list(head(levels(qe$region), 2))
+  rtests <- list(head(levels(qe$region), 1), head(levels(qe$region), 2))
   for (r in rtests) {
     expect_equal(droplevels(dplyr::filter(qe, region %in% r)),
                  read.snapshot(tmpfile, list(region = r)))


### PR DESCRIPTION
- fix read.snapshot documentation
- read entire snapshot if grep, sed, head or tail do not exist, or something goes wrong and the file does not exist after the commands