### PR TITLE
improve+reduce fails+warnings in read+write functions; fix sorting order in quitteSort 

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,7 +1,8 @@
-ValidationKey: '617921568'
+ValidationKey: '618891372'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'
 AcceptedNotes: Imports includes .* non-default packages.
 AutocreateReadme: yes
 allowLinterWarnings: yes
+enforceVersionUpdate: no

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -23,6 +23,7 @@ jobs:
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: |
+            gamstransfer=?ignore
             any::lucode2
             any::covr
             any::madrat
@@ -48,6 +49,11 @@ jobs:
         shell: Rscript {0}
         run: lucode2:::validkey(stopIfInvalid = TRUE)
 
+      - name: Verify that lucode2::buildLibrary was successful
+        if: github.event_name == 'pull_request'
+        shell: Rscript {0}
+        run: lucode2:::isVersionUpdated()
+
       - name: Checks
         shell: Rscript {0}
         run: |
@@ -56,6 +62,8 @@ jobs:
 
       - name: Test coverage
         shell: Rscript {0}
-        run: covr::codecov(quiet = FALSE)
+        run: |
+          nonDummyTests <- setdiff(list.files("./tests/testthat/"), c("test-dummy.R", "_snaps"))
+          if(length(nonDummyTests) > 0) covr::codecov(quiet = FALSE)
         env:
           NOT_CRAN: "true"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@
 exclude: '^tests/testthat/_snaps/.*$'
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.5.0
     hooks:
     -   id: check-case-conflict
     -   id: check-json
@@ -15,7 +15,7 @@ repos:
     -   id: mixed-line-ending
 
 -   repo: https://github.com/lorenzwalthert/precommit
-    rev: v0.3.2.9021
+    rev: v0.4.0
     hooks:
     -   id: parsable-R
     -   id: deps-in-desc

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,7 +3,7 @@ message: If you use this software, please cite it using the metadata from this f
 type: software
 title: 'quitte: Bits and pieces of code to use with quitte-style data frames'
 version: 0.3128.4
-date-released: '2024-01-30'
+date-released: '2024-03-01'
 abstract: A collection of functions for easily dealing with quitte-style data frames,
   doing multi-model comparisons and plots.
 authors:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Type: Package
 Package: quitte
 Title: Bits and pieces of code to use with quitte-style data frames
 Version: 0.3128.4
-Date: 2024-01-30
+Date: 2024-03-01
 Authors@R: c(
     person("Michaja", "Pehl", , "pehl@pik-potsdam.de", role = c("aut", "cre")),
     person("Nico", "Bauer", , "nicolasb@pik-potsdam.de", role = "aut"),

--- a/R/quitteSort.R
+++ b/R/quitteSort.R
@@ -20,6 +20,6 @@ quitteSort <- function(x) {
   }
 
   x %>%
-    arrange(.data$model, .data$scenario, .data$region, .data$variable,
-            .data$unit, .data$period)
+    arrange(.data$model, .data$scenario, .data$variable,
+            .data$unit, .data$region, .data$period)
 }

--- a/R/read.quitte.R
+++ b/R/read.quitte.R
@@ -130,7 +130,7 @@ read.quitte <- function(file,
                  paste(setdiff(default.columns, header[1:5]), collapse = ", "))
 
         if (length(period.columns) == 0) {
-            stop("No column name found that could be understood as a 4-digit year.")
+            stop("No column name found that could be understood as a 4-digit year in file ", f, ".")
         }
 
         if (last(period.columns) != length(header))

--- a/R/read.quitte.R
+++ b/R/read.quitte.R
@@ -129,6 +129,10 @@ read.quitte <- function(file,
             stop("missing default columns in header of file ", f, ": ",
                  paste(setdiff(default.columns, header[1:5]), collapse = ", "))
 
+        if (length(period.columns) == 0) {
+            stop("No column name found that could be understood as a 4-digit year.")
+        }
+
         if (last(period.columns) != length(header))
             stop("unallowed extra columns in header of file ", f)
 

--- a/R/write.IAMCxlsx.R
+++ b/R/write.IAMCxlsx.R
@@ -23,7 +23,7 @@
 #' @export
 write.IAMCxlsx <- function(x, path, append = FALSE) {
     x <- as.quitte(x)
-    if (nrow(x) == 0) warning("Empty data frame written to ", path)
+    if (nrow(x) == 0) warning("Writing empty data frame to ", path)
     default_columns <- c('Model', 'Scenario', 'Region', 'Variable', 'Unit',
                          'Period', 'Value')
 

--- a/R/write.IAMCxlsx.R
+++ b/R/write.IAMCxlsx.R
@@ -23,6 +23,7 @@
 #' @export
 write.IAMCxlsx <- function(x, path, append = FALSE) {
     x <- as.quitte(x)
+    if (nrow(x) == 0) warning("Empty data frame written to ", path)
     default_columns <- c('Model', 'Scenario', 'Region', 'Variable', 'Unit',
                          'Period', 'Value')
 

--- a/R/write.IAMCxlsx.R
+++ b/R/write.IAMCxlsx.R
@@ -22,18 +22,11 @@
 
 #' @export
 write.IAMCxlsx <- function(x, path, append = FALSE) {
-
+    x <- as.quitte(x)
     default_columns <- c('Model', 'Scenario', 'Region', 'Variable', 'Unit',
                          'Period', 'Value')
 
     . <- NULL
-
-    # guardians
-    if (   !is.data.frame(x)
-        || !all(c('model', 'scenario', 'region', 'variable', 'unit', 'period',
-                  'value') %in% tolower(names(x)))) {
-        stop('x must be a quitte data frame')
-    }
 
     if (append && file.exists(path)) {
         x <- rbind(read.quitte(path), x)

--- a/R/write.mif.R
+++ b/R/write.mif.R
@@ -28,6 +28,7 @@
 write.mif <- function(x, path, comment_header = NULL, comment = '#',
                       append = FALSE) {
     x <- as.quitte(x)
+    if (nrow(x) == 0) warning("Empty data frame written to ", path)
     default_columns <- c('Model', 'Scenario', 'Region', 'Variable', 'Unit',
                          'Period', 'Value')
 

--- a/R/write.mif.R
+++ b/R/write.mif.R
@@ -28,7 +28,7 @@
 write.mif <- function(x, path, comment_header = NULL, comment = '#',
                       append = FALSE) {
     x <- as.quitte(x)
-    if (nrow(x) == 0) warning("Empty data frame written to ", path)
+    if (nrow(x) == 0) warning("Writing empty data frame to ", path)
     default_columns <- c('Model', 'Scenario', 'Region', 'Variable', 'Unit',
                          'Period', 'Value')
 

--- a/R/write.mif.R
+++ b/R/write.mif.R
@@ -27,18 +27,11 @@
 #' @export
 write.mif <- function(x, path, comment_header = NULL, comment = '#',
                       append = FALSE) {
-
+    x <- as.quitte(x)
     default_columns <- c('Model', 'Scenario', 'Region', 'Variable', 'Unit',
                          'Period', 'Value')
 
     . <- NULL
-
-    # guardians
-    if (   !is.data.frame(x)
-        || !all(c('model', 'scenario', 'region', 'variable', 'unit', 'period',
-                  'value') %in% tolower(names(x)))) {
-        stop('x must be a quitte data frame')
-    }
 
     # make column names upper-case
     x <- x %>%

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ In case of questions / problems please contact Michaja Pehl <michaja.pehl@pik-po
 
 To cite package **quitte** in publications use:
 
-Pehl M, Bauer N, Hilaire J, Levesque A, Luderer G, Schultes A, Dietrich J, Richters O (2024). _quitte: Bits and pieces of code to use with quitte-style data frames_. R package version 0.3128.4, <https://github.com/pik-piam/quitte>.
+Pehl M, Bauer N, Hilaire J, Levesque A, Luderer G, Schultes A, Dietrich J, Richters O (2024). _quitte: Bits and pieces of code to use with quitte-style data frames_. R package version 0.3128.4, <URL: https://github.com/pik-piam/quitte>.
 
 A BibTeX entry for LaTeX users is
 

--- a/man/cartesian.Rd
+++ b/man/cartesian.Rd
@@ -2,25 +2,26 @@
 % Please edit documentation in R/cartesian.R
 \name{cartesian}
 \alias{cartesian}
-\title{Generate cartesian product from to character vectors}
+\title{Generate Cartesian product from character vectors}
 \usage{
-cartesian(x, y, sep = ".")
+cartesian(..., sep = ".")
 }
 \arguments{
-\item{x, y}{objects that can be coerced to character vectors}
+\item{...}{objects that can be coerced to character vectors}
 
-\item{sep}{a character string that will seperate the elements of \code{x}
-and \code{y} in the output. Defaults to \code{'.'}.}
+\item{sep}{a character string that will separate the elements of \code{...} in the
+output.  Defaults to \code{'.'}.}
 }
 \value{
-A character vector of the concatenated elements of \code{x} and
-\code{y}.
+A character vector of the concatenated elements of \code{...}.
 }
 \description{
-Generate cartesian product from to character vectors
+Generate Cartesian product from character vectors
 }
 \examples{
-cartesian(c('a', 'b'), 1:3)
-# [1] "a.1" "a.2" "a.3" "b.1" "b.2" "b.3"
+cartesian(c('a', 'b'), 1:3, c('X', 'Y', 'Z'))
+#  [1] "a.1.X" "a.1.Y" "a.1.Z" "a.2.X" "a.2.Y" "a.2.Z" "a.3.X" "a.3.Y"
+#  [9] "a.3.Z" "b.1.X" "b.1.Y" "b.1.Z" "b.2.X" "b.2.Y" "b.2.Z" "b.3.X"
+# [17] "b.3.Y" "b.3.Z"
 
 }

--- a/man/quitte-package.Rd
+++ b/man/quitte-package.Rd
@@ -3,7 +3,6 @@
 \docType{package}
 \name{quitte-package}
 \alias{quitte-package}
-\alias{_PACKAGE}
 \alias{quitte}
 \title{The quitte R package}
 \description{

--- a/man/read_mif_header.Rd
+++ b/man/read_mif_header.Rd
@@ -4,7 +4,7 @@
 \alias{read_mif_header}
 \title{Read .mif Header}
 \usage{
-read_mif_header(file, sep, comment)
+read_mif_header(file, sep = ";", comment = "#")
 }
 \arguments{
 \item{file}{A path to a \code{.mif} file.}
@@ -12,7 +12,7 @@ read_mif_header(file, sep, comment)
 \item{sep}{Column separator, defaults to ";".}
 
 \item{comment}{A character which at line start signifies the optional comment
-header with metadata at the head of \code{file}.}
+header with metadata at the head of \code{file}, defaults to "#".}
 }
 \value{
 A \code{list} with elements \code{header}, \code{comment_header}, and

--- a/tests/testthat/test-write.IAMCxlsx.R
+++ b/tests/testthat/test-write.IAMCxlsx.R
@@ -39,3 +39,11 @@ test_that(
     writexl::write_xlsx(list("data" = quitte_incomplete), f2)
     expect_warning(object = read.quitte(f2), "misses default columns")
   })
+
+test_that(
+  'write empty data to a .xlsx file',
+  {
+    f3 <- paste0(tempfile(), ".xlsx")
+    expect_warning(write.IAMCxlsx(filter(quitte_example_data, model == "x"), f3),
+                   "Empty data frame written")
+  })

--- a/tests/testthat/test-write.IAMCxlsx.R
+++ b/tests/testthat/test-write.IAMCxlsx.R
@@ -45,5 +45,5 @@ test_that(
   {
     f3 <- paste0(tempfile(), ".xlsx")
     expect_warning(write.IAMCxlsx(filter(quitte_example_data, model == "x"), f3),
-                   "Empty data frame written")
+                   "Writing empty data frame")
   })

--- a/tests/testthat/test-write.mif.R
+++ b/tests/testthat/test-write.mif.R
@@ -35,3 +35,12 @@ test_that(
       expected = read_lines(system.file('extdata', 'comment_header.mif',
                                         package = 'quitte')))
   })
+
+# expect warning for empty data
+test_that(
+  desc = 'write .mif file passing empty data',
+  code = {
+    f <- tempfile()
+    expect_warning(write.mif(filter(quitte_example_data, model == "x"), f),
+                   "Empty data frame written")
+  })

--- a/tests/testthat/test-write.mif.R
+++ b/tests/testthat/test-write.mif.R
@@ -42,5 +42,5 @@ test_that(
   code = {
     f <- tempfile()
     expect_warning(write.mif(filter(quitte_example_data, model == "x"), f),
-                   "Empty data frame written")
+                   "Writing empty data frame")
   })


### PR DESCRIPTION
1. If somehow an empty data.frame was written to a mif file and then read with read.quitte, the error message was incomprehensible:
```
Error in `if (last(period.columns) != length(header)) ...`:
! missing value where TRUE/FALSE needed
Run `rlang::last_trace()` to see where the error occurred.
```
Now, fail with
```
No column name found that could be understood as a 4-digit year.
```

2. let write.mif and write.IAMCxlsx try to convert to quitte instead of failing immediately, and warn in case of empty data

3. sort order in quitteSort according to function description, was somehow changed unnoticed in [this commit](https://github.com/pik-piam/quitte/commit/08450834a8fb67bb796cd190f22d4b25ce7624e7)