### PR TITLE
use filter.function in read.quitte also for xlsx

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,8 +1,10 @@
-ValidationKey: '621127780'
+ValidationKey: '622024326'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'
-AcceptedNotes: Imports includes .* non-default packages.
+AcceptedNotes:
+- Imports includes .* non-default packages.
+- checking installed package size
 AutocreateReadme: yes
 allowLinterWarnings: yes
 enforceVersionUpdate: no

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-pandoc@v2
 
@@ -23,7 +23,6 @@ jobs:
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: |
-            gamstransfer=?ignore
             any::lucode2
             any::covr
             any::madrat
@@ -36,7 +35,7 @@ jobs:
           # gms, goxygen, GDPuc) will usually have an outdated binary version
           # available; by using extra-packages we get the newest version
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: 3.9
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@
 exclude: '^tests/testthat/_snaps/.*$'
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: 2c9f875913ee60ca25ce70243dc24d5b6415598c  # frozen: v4.6.0
     hooks:
     -   id: check-case-conflict
     -   id: check-json
@@ -15,7 +15,7 @@ repos:
     -   id: mixed-line-ending
 
 -   repo: https://github.com/lorenzwalthert/precommit
-    rev: v0.4.1
+    rev: 7910e0323d7213f34275a7a562b9ef0fde8ce1b9  # frozen: v0.4.2
     hooks:
     -   id: parsable-R
     -   id: deps-in-desc

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'quitte: Bits and pieces of code to use with quitte-style data frames'
-version: 0.3131.0
-date-released: '2024-04-25'
+version: 0.3131.1
+date-released: '2024-05-23'
 abstract: A collection of functions for easily dealing with quitte-style data frames,
   doing multi-model comparisons and plots.
 authors:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: quitte
 Title: Bits and pieces of code to use with quitte-style data frames
-Version: 0.3131.0
-Date: 2024-04-25
+Version: 0.3131.1
+Date: 2024-05-23
 Authors@R: c(
     person("Michaja", "Pehl", , "pehl@pik-potsdam.de", role = c("aut", "cre")),
     person("Nico", "Bauer", , "nicolasb@pik-potsdam.de", role = "aut"),

--- a/R/read.quitte.R
+++ b/R/read.quitte.R
@@ -85,15 +85,14 @@ read.quitte <- function(file,
                         factors = TRUE,
                         drop.na = FALSE,
                         comment = '#',
-                        filter.function = NULL,
+                        filter.function = identity,
                         chunk_size = 200000L) {
 
     if (!length(file))
         stop('\'file\' is empty.')
 
-    if (is.null(filter.function)) filter.function <- identity
-    if (! is.function(filter.function)
-        && 1 != length(formals(filter.function)))
+    if (!(   is.function(filter.function)
+          && 1 == length(formals(filter.function))))
         stop('`filter.function` must be a function taking only one argument.')
 
     .read.quitte <- function(f, sep, quote, na.strings, convert.periods,
@@ -157,8 +156,7 @@ read.quitte <- function(file,
         # the callback function accepts a chunk of data, `x`, pivots the periods
         # to long format (dropping NAs if required), converts the periods to
         # integer or POSIXct values as required, and applies the
-        # `filter.function`.  If the `filter.function` is `NULL`, it just
-        # returns the processed data.
+        # `filter.function`.
         chunk_callback <- DataFrameCallback$new(
             (function(FilterF, convert.periods, drop.na) {
 

--- a/R/read.snapshot.R
+++ b/R/read.snapshot.R
@@ -1,14 +1,15 @@
-#' Reads IAMC-style .csv files obtained as a IIASA snapshot into a quitte data frame,
-#' filtering the data. This function is helpful if the csv file is large and R runs out
-#' of memory loading it completely. This function requires head, tail and grep on your system.
-#' If not supported, use read.quitte().
+#' Reads IAMC-style .csv or .xlsx files obtained as a IIASA snapshot into a quitte data frame,
+#' allowing to filter the loaded data. If head, tail and grep are on your system, a pre-filtering
+#' improves performance.
 #'
 #' @md
 #' @param file Path of single IAMC-style .csv/.mif file
-#' @param keep list with quitte columns as names and data points that should be kept. Using 'grep',
-#' this list is used to extract the data before reading it into R. The more you restrict the data here,
-#' the faster the data is read.
+#' @param keep list with quitte columns as names and data points that should be kept.
+#' If head, tail and grep are available, this list is used to extract the data before reading it
+#' into R. The more you restrict the data here, the faster the data is read.
 #' @param filter.function A function used to filter data during read, see read.quitte description.
+#' This allows for more complex filtering, but no performance-enhancing pre-filtering using grep is used.
+#' The 'keep' list and the 'filter.function' can be combined.
 #'
 #' @return A quitte data frame.
 #'
@@ -24,7 +25,7 @@
 #'
 #' @export
 
-read.snapshot <- function(file, keep = list(), filter.function = NULL) {
+read.snapshot <- function(file, keep = list(), filter.function = identity) {
   unknowntype <- setdiff(names(keep), c("model", "scenario", "region", "variable", "unit", "period"))
   if (length(unknowntype) > 0) {
     stop("Unknown types in 'keep': ", toString(unknowntype))
@@ -72,9 +73,7 @@ read.snapshot <- function(file, keep = list(), filter.function = NULL) {
     for (t in names(keep)) {
       data <- droplevels(filter(data, .data[[t]] %in% keep[[t]]))
     }
-    if (is.function(filter.function)) {
-      data <- filter.function(data)
-    }
+    data <- filter.function(data)
     return(data)
   }
   # read file and do correct filtering

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Bits and pieces of code to use with quitte-style data frames
 
-R package **quitte**, version **0.3131.0**
+R package **quitte**, version **0.3131.1**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/quitte)](https://cran.r-project.org/package=quitte)  [![R build status](https://github.com/pik-piam/quitte/workflows/check/badge.svg)](https://github.com/pik-piam/quitte/actions) [![codecov](https://codecov.io/gh/pik-piam/quitte/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/quitte) [![r-universe](https://pik-piam.r-universe.dev/badges/quitte)](https://pik-piam.r-universe.dev/builds)
 
@@ -47,7 +47,7 @@ In case of questions / problems please contact Michaja Pehl <michaja.pehl@pik-po
 
 To cite package **quitte** in publications use:
 
-Pehl M, Bauer N, Hilaire J, Levesque A, Luderer G, Schultes A, Dietrich J, Richters O (2024). _quitte: Bits and pieces of code to use with quitte-style data frames_. R package version 0.3131.0, <https://github.com/pik-piam/quitte>.
+Pehl M, Bauer N, Hilaire J, Levesque A, Luderer G, Schultes A, Dietrich J, Richters O (2024). _quitte: Bits and pieces of code to use with quitte-style data frames_. R package version 0.3131.1, <URL: https://github.com/pik-piam/quitte>.
 
 A BibTeX entry for LaTeX users is
 
@@ -56,7 +56,7 @@ A BibTeX entry for LaTeX users is
   title = {quitte: Bits and pieces of code to use with quitte-style data frames},
   author = {Michaja Pehl and Nico Bauer and Jérôme Hilaire and Antoine Levesque and Gunnar Luderer and Anselm Schultes and Jan Philipp Dietrich and Oliver Richters},
   year = {2024},
-  note = {R package version 0.3131.0},
+  note = {R package version 0.3131.1},
   url = {https://github.com/pik-piam/quitte},
 }
 ```

--- a/man/read.quitte.Rd
+++ b/man/read.quitte.Rd
@@ -14,7 +14,7 @@ read.quitte(
   factors = TRUE,
   drop.na = FALSE,
   comment = "#",
-  filter.function = NULL,
+  filter.function = identity,
   chunk_size = 200000L
 )
 }

--- a/man/read.quitte.Rd
+++ b/man/read.quitte.Rd
@@ -61,8 +61,8 @@ Reads IAMC-style .csv or .xlsx files into a quitte data frame.
 }
 \details{
 In order to process large data sets, like IIASA data base snapshots,
-\code{read.quitte()} reads provided files (other then Excel files) in chunks of
-\code{chunk_size} lines, and applies \code{filter.function()} to the chunks.  This
+\code{read.quitte()} reads provided files in chunks of \code{chunk_size} lines
+(not for Excel files), and applies \code{filter.function()} to the chunks.  This
 allows for filtering data piece-by-piece, without exceeding available memory.
 \code{filter.function} is a function taking one argument, a quitte data frame of
 the read chunk, and is expected to return a data frame.  Usually it should

--- a/man/read.snapshot.Rd
+++ b/man/read.snapshot.Rd
@@ -2,30 +2,30 @@
 % Please edit documentation in R/read.snapshot.R
 \name{read.snapshot}
 \alias{read.snapshot}
-\title{Reads IAMC-style .csv files obtained as a IIASA snapshot into a quitte data frame,
-filtering the data. This function is helpful if the csv file is large and R runs out
-of memory loading it completely. This function requires head, tail and grep on your system.
-If not supported, use read.quitte().}
+\title{Reads IAMC-style .csv or .xlsx files obtained as a IIASA snapshot into a quitte data frame,
+allowing to filter the loaded data. If head, tail and grep are on your system, a pre-filtering
+improves performance.}
 \usage{
-read.snapshot(file, keep = list(), filter.function = NULL)
+read.snapshot(file, keep = list(), filter.function = identity)
 }
 \arguments{
 \item{file}{Path of single IAMC-style .csv/.mif file}
 
-\item{keep}{list with quitte columns as names and data points that should be kept. Using 'grep',
-this list is used to extract the data before reading it into R. The more you restrict the data here,
-the faster the data is read.}
+\item{keep}{list with quitte columns as names and data points that should be kept.
+If head, tail and grep are available, this list is used to extract the data before reading it
+into R. The more you restrict the data here, the faster the data is read.}
 
-\item{filter.function}{A function used to filter data during read, see read.quitte description.}
+\item{filter.function}{A function used to filter data during read, see read.quitte description.
+This allows for more complex filtering, but no performance-enhancing pre-filtering using grep is used.
+The 'keep' list and the 'filter.function' can be combined.}
 }
 \value{
 A quitte data frame.
 }
 \description{
-Reads IAMC-style .csv files obtained as a IIASA snapshot into a quitte data frame,
-filtering the data. This function is helpful if the csv file is large and R runs out
-of memory loading it completely. This function requires head, tail and grep on your system.
-If not supported, use read.quitte().
+Reads IAMC-style .csv or .xlsx files obtained as a IIASA snapshot into a quitte data frame,
+allowing to filter the loaded data. If head, tail and grep are on your system, a pre-filtering
+improves performance.
 }
 \examples{
 \dontrun{

--- a/man/write.mif.Rd
+++ b/man/write.mif.Rd
@@ -2,9 +2,28 @@
 % Please edit documentation in R/write.mif.R
 \name{write.mif}
 \alias{write.mif}
+\alias{write.IAMCcsv}
 \title{Write .mif file}
 \usage{
-write.mif(x, path, comment_header = NULL, comment = "#", append = FALSE)
+write.mif(
+  x,
+  path,
+  comment_header = NULL,
+  comment = "#",
+  append = FALSE,
+  sep = ";",
+  na = "NA"
+)
+
+write.IAMCcsv(
+  x,
+  path,
+  comment_header = NULL,
+  comment = "#",
+  append = FALSE,
+  sep = ",",
+  na = ""
+)
 }
 \arguments{
 \item{x}{A \code{\link{quitte}} data frame.}
@@ -19,10 +38,19 @@ existing comment characters in file \code{path} if \code{append} is \code{TRUE}.
 
 \item{append}{Overwrite existing files (\code{FALSE}, default), or append to them
 (\code{TRUE}).}
+
+\item{sep}{Single character used to separate fields within a record.
+Defaults to \verb{;}.}
+
+\item{na}{String used for \code{NA} elements.  Defaults to \code{'NA'} for
+\code{write.mif()} and to \code{''} for \code{write.IAMCcsv()}.}
 }
 \description{
 A wrapper around \code{\link[readr:read_lines]{readr::write_lines}} for writing files conforming to the
 \href{https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Model-Intercomparison-File-Format-(mif)}{\code{.mif} standard}.
+}
+\details{
+\code{write.IAMCcsv()} uses commas as filed separators instead of semi-colons.
 }
 \examples{
 write.mif(quitte_example_data, tempfile())


### PR DESCRIPTION
- while it does not help with memory stuff, it is better if the filter.function feature is not only used for specific file types.
- for `filter.function = NULL`, replace early with the `identity` function to avoid duplicating code
- I got a note about package size, so just ignore it as in other piam packages