### PR TITLE
allow as.quitte + read.quitte + read.snapshot to read rds files

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '623091040'
+ValidationKey: '623603320'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'quitte: Bits and pieces of code to use with quitte-style data frames'
-version: 0.3133.0
-date-released: '2024-06-14'
+version: 0.3134.0
+date-released: '2024-06-24'
 abstract: A collection of functions for easily dealing with quitte-style data frames,
   doing multi-model comparisons and plots.
 authors:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: quitte
 Title: Bits and pieces of code to use with quitte-style data frames
-Version: 0.3133.0
-Date: 2024-06-14
+Version: 0.3134.0
+Date: 2024-06-24
 Authors@R: c(
     person("Michaja", "Pehl", , "pehl@pik-potsdam.de", role = c("aut", "cre")),
     person("Nico", "Bauer", , "nicolasb@pik-potsdam.de", role = "aut"),

--- a/R/as.quitte.R
+++ b/R/as.quitte.R
@@ -32,7 +32,7 @@ as.quitte <- function(x, periodClass = "integer", addNA = FALSE, na.rm = FALSE) 
 
 #' @export
 as.quitte.character <- function(x, periodClass = "integer", addNA = FALSE, na.rm = FALSE) { # nolint
-    if (all(file.exists(x) & grepl("\\.(mif|csv|xlsx?)$", x)))
+    if (all(file.exists(x) & grepl("\\.(mif|csv|rds|xlsx?)$", x)))
         return(as.quitte(read.quitte(x, sep = NULL),
                          periodClass = periodClass, addNA = addNA, na.rm = na.rm))
     stop(

--- a/R/read.quitte.R
+++ b/R/read.quitte.R
@@ -1,9 +1,9 @@
-#' Read IAMC-style .csv or .xlsx files
+#' Read IAMC-style .csv or .xlsx files, or object from rds file.
 #'
-#' Reads IAMC-style .csv or .xlsx files into a quitte data frame.
+#' Reads IAMC-style .csv or .xlsx files or object from rds file into a quitte data frame.
 #'
 #' @md
-#' @param file Path of IAMC-style .csv or xlsx. file or vector of paths to read.
+#' @param file Path of IAMC-style .csv, .xlsx, or rds file or vector of paths to read.
 #' @param sep Column separator, defaults to ";" in read_mif_header().
 #' @param quote Quote characters, empty by default.
 #' @param na.strings Entries to interpret as NA; defaults to
@@ -113,6 +113,10 @@ read.quitte <- function(file,
             }
             return(filter.function(as.quitte(data)))
         }
+        if (grepl("\\.rds$", f)) {
+            return(filter.function(as.quitte(readRDS(f))))
+        }
+
         # Check the header for correct names, periods all in one block and no
         # additional columns after the periods
 

--- a/R/read.snapshot.R
+++ b/R/read.snapshot.R
@@ -1,12 +1,12 @@
 #' Reads IAMC-style .csv or .xlsx files obtained as a IIASA snapshot into a quitte data frame,
-#' allowing to filter the loaded data. If head, tail and grep are on your system, a pre-filtering
-#' improves performance.
+#' or data from rds file, allowing to filter the loaded data.
+#' If head, tail and grep are on your system, a pre-filtering improves performance for csv files.
 #'
 #' @md
 #' @param file Path of single IAMC-style .csv/.mif file
 #' @param keep list with quitte columns as names and data points that should be kept.
-#' If head, tail and grep are available, this list is used to extract the data before reading it
-#' into R. The more you restrict the data here, the faster the data is read.
+#' If head, tail and grep are available and a csv/mif file is read, this list is used to extract the
+#' data before reading it into R. The more you restrict the data here, the faster the data is read.
 #' @param filter.function A function used to filter data during read, see read.quitte description.
 #' This allows for more complex filtering, but no performance-enhancing pre-filtering using grep is used.
 #' The 'keep' list and the 'filter.function' can be combined.
@@ -38,7 +38,7 @@ read.snapshot <- function(file, keep = list(), filter.function = identity) {
 
   # temporary file
   tmpfile <- tempfile(pattern = "data", fileext = gsub("^.*\\.", ".", basename(file)))
-  if (length(setdiff(names(keep), "period")) > 0 && !grepl("\\.xlsx?$", file)) {
+  if (length(setdiff(names(keep), "period")) > 0 && !grepl("\\.(rds|xlsx?)$", file)) {
     # check whether system commands are supported
     testcommand <- c("grep", "head", "tail")
     notavailable <- Sys.which(testcommand) == ""

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Bits and pieces of code to use with quitte-style data frames
 
-R package **quitte**, version **0.3133.0**
+R package **quitte**, version **0.3134.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/quitte)](https://cran.r-project.org/package=quitte)  [![R build status](https://github.com/pik-piam/quitte/workflows/check/badge.svg)](https://github.com/pik-piam/quitte/actions) [![codecov](https://codecov.io/gh/pik-piam/quitte/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/quitte) [![r-universe](https://pik-piam.r-universe.dev/badges/quitte)](https://pik-piam.r-universe.dev/builds)
 
@@ -47,7 +47,7 @@ In case of questions / problems please contact Michaja Pehl <michaja.pehl@pik-po
 
 To cite package **quitte** in publications use:
 
-Pehl M, Bauer N, Hilaire J, Levesque A, Luderer G, Schultes A, Dietrich J, Richters O (2024). _quitte: Bits and pieces of code to use with quitte-style data frames_. R package version 0.3133.0, <https://github.com/pik-piam/quitte>.
+Pehl M, Bauer N, Hilaire J, Levesque A, Luderer G, Schultes A, Dietrich J, Richters O (2024). _quitte: Bits and pieces of code to use with quitte-style data frames_. R package version 0.3134.0, <URL: https://github.com/pik-piam/quitte>.
 
 A BibTeX entry for LaTeX users is
 
@@ -56,7 +56,7 @@ A BibTeX entry for LaTeX users is
   title = {quitte: Bits and pieces of code to use with quitte-style data frames},
   author = {Michaja Pehl and Nico Bauer and Jérôme Hilaire and Antoine Levesque and Gunnar Luderer and Anselm Schultes and Jan Philipp Dietrich and Oliver Richters},
   year = {2024},
-  note = {R package version 0.3133.0},
+  note = {R package version 0.3134.0},
   url = {https://github.com/pik-piam/quitte},
 }
 ```

--- a/man/calc_addVariable.Rd
+++ b/man/calc_addVariable.Rd
@@ -35,7 +35,9 @@ calc_addVariable_(
 \arguments{
 \item{data}{A data frame.}
 
-\item{...}{Name-value pairs of calculation formulas or a single filename. See details.}
+\item{...}{Formulas to calculate new variables.  Either name-value pairs,
+the path to a .csv file, the content of a .csv file as a string, or a data
+frame.  See details.}
 
 \item{units}{Character vector of units corresponding to new variables.  Must
 be of length equal to \code{...} or of length one (in which case all new
@@ -70,29 +72,22 @@ already exist}
 variable is missing.  If \code{TRUE}, warn, and skip that calculation.
 If \code{"silent"}, skip without warning.}
 
-\item{.dots}{Used to work around non-standard evaluation.  See details.}
-}
-\value{
-A data frame.
-}
-\description{
-Calculate new variables from existing ones, using generic formulas.
-}
-\details{
-\code{...} is a list of name-value pairs with the general format
+\item{.dots}{Used to work around non-standard evaluation.  See details.
+
+If \code{...} is a list of name-value pairs, it has the general format
 
 \if{html}{\out{<div class="sourceCode">}}\preformatted{"lhs" = "rhs + calculations - formula", "`lhs 2`" = "lhs / `rhs 2`"
 }\if{html}{\out{</div>}}
 
-where \code{lhs} are the names of new variables to be calculated and
-\code{rhs} are the variables to calculate from. If \code{lhs} and \code{rhs}
-are no proper \emph{identifiers}, they need to be quoted (see
-\link[base:Quotes]{Quotes} for details). When in doubt, just quote.
+where \code{lhs} are the names of new variables to be calculated and \code{rhs} are the
+variables to calculate from.  If \code{lhs} and \code{rhs} are no proper \emph{identifiers},
+they need to be quoted (see \link[base:Quotes]{Quotes} for details).  When in
+doubt, just quote.
 
 If the new variables should have units, set \code{units} appropriately.
 
-\code{.dots} is a named list of strings denoting formulas and optionally
-units. The general format is
+\code{.dots} is a named list of strings denoting formulas and optionally units.
+The general format is
 
 \if{html}{\out{<div class="sourceCode">}}\preformatted{list("`lhs 1`" = "`rhs` / `calculation`",
      "`lhs 2`" = "sin(`rhs 2`)")
@@ -105,14 +100,40 @@ Units are optionally included with the formulas in a vector like
 
 Units do not require quoting.
 
-As an alternative, the variable, unit and formula can be specified as a csv file in this format:
-variable;unit;formula
-Carbon Intensity|Cement;Mt CO2/Mt;\code{Emi|CO2|Cement} / \code{Production|Cement}
+As an alternative, the variable, unit and formula can be specified as a .csv
+file in this format:
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{variable;                unit;      formula
+Carbon Intensity|Cement; Mt CO2/Mt; `Emi|CO2|Cement` / `Production|Cement`
+}\if{html}{\out{</div>}}
+
+or as a single string containing the .csv content (joined by \verb{\\n} line
+breaks)
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{paste(c(
+    "variable;         unit;        formula",
+    "Consumption|pCap; US$2005/cap; 0.001 * `Consumption`/`Population`"),
+    collapse = '\\n')
+}\if{html}{\out{</div>}}
+
+or as a data frame with the same columns:
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{data.frame(
+    variable = 'Consumption|pCap',
+    unit     = 'US$2005/cap',
+    formula  = '0.001 * `Consumption`/`Population`')
+}\if{html}{\out{</div>}}
 
 \code{...} and \code{.dots} are processed in order, and variables already
 calculated in the same call can be used for further calculations. Other
 existing columns, including \code{period}, can be referenced, but this is
-not supported and the results are considered \emph{undefined}.
+not supported and the results are considered \emph{undefined}.}
+}
+\value{
+A data frame.
+}
+\description{
+Calculate new variables from existing ones, using generic formulas.
 }
 \examples{
 data <- inline.data.frame(c(

--- a/man/cartesian.Rd
+++ b/man/cartesian.Rd
@@ -2,21 +2,24 @@
 % Please edit documentation in R/cartesian.R
 \name{cartesian}
 \alias{cartesian}
-\title{Generate Cartesian product from character vectors}
+\title{Generate Cartesian Product from Vectors}
 \usage{
 cartesian(..., sep = ".")
 }
 \arguments{
-\item{...}{objects that can be coerced to character vectors}
+\item{...}{Vectors to be combined}
 
-\item{sep}{a character string that will separate the elements of \code{...} in the
-output.  Defaults to \code{'.'}.}
+\item{sep}{If a character string, that string will separate the elements of
+\code{...} (if necessary cast to \code{character}) in the output.  If \code{NULL},
+elements of \code{...} will not be cast.  Defaults to \code{'.'}.}
 }
 \value{
-A character vector of the concatenated elements of \code{...}.
+If \code{sep} is a character string, then a character vector of
+concatenated elements.  If \code{sep} is \code{NULL}, then a list of concatenated
+elements.
 }
 \description{
-Generate Cartesian product from character vectors
+Generate Cartesian Product from Vectors
 }
 \examples{
 cartesian(c('a', 'b'), 1:3, c('X', 'Y', 'Z'))
@@ -24,4 +27,24 @@ cartesian(c('a', 'b'), 1:3, c('X', 'Y', 'Z'))
 #  [9] "a.3.Z" "b.1.X" "b.1.Y" "b.1.Z" "b.2.X" "b.2.Y" "b.2.Z" "b.3.X"
 # [17] "b.3.Y" "b.3.Z"
 
+str(cartesian(c('a', 'b'), 17:19, sep = NULL))
+# List of 6
+#  $ :List of 2
+#   ..$ : chr "a"
+#   ..$ : int 17
+#  $ :List of 2
+#   ..$ : chr "a"
+#   ..$ : int 18
+#  $ :List of 2
+#   ..$ : chr "a"
+#   ..$ : int 19
+#  $ :List of 2
+#   ..$ : chr "b"
+#   ..$ : int 17
+#  $ :List of 2
+#   ..$ : chr "b"
+#   ..$ : int 18
+#  $ :List of 2
+#   ..$ : chr "b"
+#   ..$ : int 19
 }

--- a/man/read.quitte.Rd
+++ b/man/read.quitte.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/read.quitte.R
 \name{read.quitte}
 \alias{read.quitte}
-\title{Read IAMC-style .csv or .xlsx files}
+\title{Read IAMC-style .csv or .xlsx files, or object from rds file.}
 \usage{
 read.quitte(
   file,
@@ -19,7 +19,7 @@ read.quitte(
 )
 }
 \arguments{
-\item{file}{Path of IAMC-style .csv or xlsx. file or vector of paths to read.}
+\item{file}{Path of IAMC-style .csv, .xlsx, or rds file or vector of paths to read.}
 
 \item{sep}{Column separator, defaults to ";" in read_mif_header().}
 
@@ -57,7 +57,7 @@ regional settings, respectively.)}
 A quitte data frame.
 }
 \description{
-Reads IAMC-style .csv or .xlsx files into a quitte data frame.
+Reads IAMC-style .csv or .xlsx files or object from rds file into a quitte data frame.
 }
 \details{
 In order to process large data sets, like IIASA data base snapshots,

--- a/man/read.snapshot.Rd
+++ b/man/read.snapshot.Rd
@@ -3,8 +3,8 @@
 \name{read.snapshot}
 \alias{read.snapshot}
 \title{Reads IAMC-style .csv or .xlsx files obtained as a IIASA snapshot into a quitte data frame,
-allowing to filter the loaded data. If head, tail and grep are on your system, a pre-filtering
-improves performance.}
+or data from rds file, allowing to filter the loaded data.
+If head, tail and grep are on your system, a pre-filtering improves performance for csv files.}
 \usage{
 read.snapshot(file, keep = list(), filter.function = identity)
 }
@@ -12,8 +12,8 @@ read.snapshot(file, keep = list(), filter.function = identity)
 \item{file}{Path of single IAMC-style .csv/.mif file}
 
 \item{keep}{list with quitte columns as names and data points that should be kept.
-If head, tail and grep are available, this list is used to extract the data before reading it
-into R. The more you restrict the data here, the faster the data is read.}
+If head, tail and grep are available and a csv/mif file is read, this list is used to extract the
+data before reading it into R. The more you restrict the data here, the faster the data is read.}
 
 \item{filter.function}{A function used to filter data during read, see read.quitte description.
 This allows for more complex filtering, but no performance-enhancing pre-filtering using grep is used.
@@ -24,8 +24,8 @@ A quitte data frame.
 }
 \description{
 Reads IAMC-style .csv or .xlsx files obtained as a IIASA snapshot into a quitte data frame,
-allowing to filter the loaded data. If head, tail and grep are on your system, a pre-filtering
-improves performance.
+or data from rds file, allowing to filter the loaded data.
+If head, tail and grep are on your system, a pre-filtering improves performance for csv files.
 }
 \examples{
 \dontrun{

--- a/tests/testthat/test-as.quitte.R
+++ b/tests/testthat/test-as.quitte.R
@@ -94,3 +94,12 @@ test_that(
     expect_equal(nrow(as.quitte(NULL)), 0)
   }
 )
+
+test_that(
+  'as.quitte works on rds files',
+  {
+    rdsfile <- tempfile(pattern = "report", fileext = ".rds")
+    saveRDS(quitte_example_data, rdsfile)
+    expect_identical(as.quitte(rdsfile), quitte_example_data)
+  }
+)


### PR DESCRIPTION
- to allow a quick loading like `as.quitte(c("report.rds", "iiasa.xlsx"))`
- to be able to use the filter functionality in read.quitte / read.snapshot