### PR TITLE
Bugfix: `write.gdx` preserves dimension names

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '646693640'
+ValidationKey: '648253140'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -11,37 +11,22 @@ jobs:
   check:
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft == false
+    container:
+      image: ghcr.io/pik-piam/ci-image:latest
 
     steps:
       - uses: actions/checkout@v4
 
-      - uses: r-lib/actions/setup-pandoc@v2
-
-      - uses: r-lib/actions/setup-r@v2
-        with:
-          use-public-rspm: true
-          extra-repositories: "https://rse.pik-potsdam.de/r/packages"
-
-      - uses: r-lib/actions/setup-r-dependencies@v2
-        with:
-          extra-packages: |
-            lucode2
-            covr
-            madrat
-            magclass
-            citation
-            gms
-            goxygen
-            GDPuc
-          # piam packages also available on CRAN (madrat, magclass, citation,
-          # gms, goxygen, GDPuc) will usually have an outdated binary version
-          # available; by using extra-packages we get the newest version
-
+      - name: Install package and dependencies
+        shell: Rscript {0}
+        run: |
+          options(repos = c(pikpiam = 'https://pik-piam.r-universe.dev',
+                            CRAN = Sys.getenv('RSPM')))
+          pak::pak()
+          
       - name: Run pre-commit checks
         shell: bash
         run: |
-          python -m pip install pre-commit
-          python -m pip freeze --local
           pre-commit run --show-diff-on-failure --color=always --all-files
 
       - name: Verify validation key

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -18,20 +18,18 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     permissions:
       contents: write
+    container:
+      image: ghcr.io/pik-piam/ci-image:latest
     steps:
       - uses: actions/checkout@v4
 
-      - uses: r-lib/actions/setup-pandoc@v2
-
-      - uses: r-lib/actions/setup-r@v2
-        with:
-          use-public-rspm: true
-          extra-repositories: "https://rse.pik-potsdam.de/r/packages"
-
-      - uses: r-lib/actions/setup-r-dependencies@v2
-        with:
-          extra-packages: any::pkgdown, local::.
-          needs: website
+      - name: Install
+        shell: Rscript {0}
+        run: |
+          options(repos = c(pikpiam = 'https://pik-piam.r-universe.dev',
+                            CRAN = Sys.getenv('RSPM')))
+          pak::pak(".")
+          pak::pkg_install("tidyverse/tidytemplate")
 
       - name: Build site
         run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,6 @@
 quitte.Rproj
 
 # Copilot context files
+AGENT.md
 .github/copilot-instructions.md
-.github/instructions/
-.github/prompts/
+remind-context/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
     -   id: mixed-line-ending
 
 -   repo: https://github.com/lorenzwalthert/precommit
-    rev: 3b70240796cdccbe1474b0176560281aaded97e6  # frozen: v0.4.3.9003
+    rev: v0.4.3.9021
     hooks:
     -   id: parsable-R
     -   id: deps-in-desc

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'quitte: Bits and pieces of code to use with quitte-style data frames'
-version: 0.3148.0
-date-released: '2026-03-31'
+version: 0.3149.0
+date-released: '2026-05-13'
 abstract: A collection of functions for easily dealing with quitte-style data frames,
   doing multi-model comparisons and plots.
 authors:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: quitte
 Title: Bits and pieces of code to use with quitte-style data frames
-Version: 0.3148.0
-Date: 2026-03-31
+Version: 0.3149.0
+Date: 2026-05-13
 Authors@R: c(
     person("Michaja", "Pehl", , "pehl@pik-potsdam.de", role = c("aut", "cre")),
     person("Nico", "Bauer", , "nicolasb@pik-potsdam.de", role = "aut"),

--- a/R/magclass_to_tibble.R
+++ b/R/magclass_to_tibble.R
@@ -15,7 +15,7 @@
 #' @importFrom tidyselect all_of
 #'
 #' @examples
-#' magclass_to_tibble(magclass::maxample('pop'))
+#' \donttest{magclass_to_tibble(magclass::maxample('pop'))}
 
 #' @export
 magclass_to_tibble <- function(m, colnames = NULL) {

--- a/R/write.gdx.R
+++ b/R/write.gdx.R
@@ -66,6 +66,11 @@ write.gdx <- function(qf, path, varmap, dimCols = c("region", "period"), verbose
     # build gamstransfer container ----
     container <- gamstransfer::Container$new()
 
+    # named sets so the GDX stores proper dimension names (not "*")
+    for (col in dimCols) {
+        container$addSet(col, records = unique(as.character(qf[[col]])))
+    }
+
     for (quitteVar in mappedVars) {
         records <- qf %>%
             filter(.data[['variable']] == quitteVar) %>%
@@ -76,7 +81,7 @@ write.gdx <- function(qf, path, varmap, dimCols = c("region", "period"), verbose
 
         container$addParameter(
             name    = varmap[[quitteVar]],
-            domain  = rep('*', length(dimCols)),
+            domain  = dimCols,
             records = as.data.frame(records)
         )
     }

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Bits and pieces of code to use with quitte-style data frames
 
-R package **quitte**, version **0.3148.0**
+R package **quitte**, version **0.3149.0**
 
-[![CRAN status](https://www.r-pkg.org/badges/version/quitte)](https://cran.r-project.org/package=quitte) [![R build status](https://github.com/pik-piam/quitte/workflows/check/badge.svg)](https://github.com/pik-piam/quitte/actions) [![codecov](https://codecov.io/gh/pik-piam/quitte/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/quitte) [![r-universe](https://pik-piam.r-universe.dev/badges/quitte)](https://pik-piam.r-universe.dev/builds)
+   [![R build status](https://github.com/pik-piam/quitte/workflows/check/badge.svg)](https://github.com/pik-piam/quitte/actions) [![codecov](https://codecov.io/gh/pik-piam/quitte/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/quitte) [![r-universe](https://pik-piam.r-universe.dev/badges/quitte)](https://pik-piam.r-universe.dev/builds)
 
 ## Purpose and Functionality
 
@@ -47,7 +47,7 @@ In case of questions / problems please contact Falk Benke <benke@pik-potsdam.de>
 
 To cite package **quitte** in publications use:
 
-Pehl M, Bauer N, Hilaire J, Levesque A, Luderer G, Schultes A, Dietrich J, Richters O, Rüter T (2026). "quitte: Bits and pieces of code to use with quitte-style data frames." Version: 0.3148.0, <https://github.com/pik-piam/quitte>.
+Pehl M, Bauer N, Hilaire J, Levesque A, Luderer G, Schultes A, Dietrich J, Richters O, Rüter T (2026). "quitte: Bits and pieces of code to use with quitte-style data frames." Version: 0.3149.0, <https://github.com/pik-piam/quitte>.
 
 A BibTeX entry for LaTeX users is
 
@@ -55,9 +55,9 @@ A BibTeX entry for LaTeX users is
 @Misc{,
   title = {quitte: Bits and pieces of code to use with quitte-style data frames},
   author = {Michaja Pehl and Nico Bauer and Jérôme Hilaire and Antoine Levesque and Gunnar Luderer and Anselm Schultes and Jan Philipp Dietrich and Oliver Richters and Tonn Rüter},
-  date = {2026-03-31},
+  date = {2026-05-13},
   year = {2026},
   url = {https://github.com/pik-piam/quitte},
-  note = {Version: 0.3148.0},
+  note = {Version: 0.3149.0},
 }
 ```


### PR DESCRIPTION
`write.gdx()` was using wildcard `*` as the GAMS domain, so dimension names were lost in the GDX and came back as `X.`/`X..1` on read. Fixed by adding named sets to the container before writing parameters.